### PR TITLE
Add WsClient: resilient WebSocket subscriptions with auto-reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,37 @@ const key = try eth.hd_wallet.deriveEthAccount(seed, 0);
 const addr = key.toAddress();
 ```
 
+### Resilient WebSocket subscriptions (production bots)
+
+`ws_client.WsClient` wraps `ws_transport` with three features bots need: transparent reconnect with exponential backoff + jitter, multiplexed subscriptions on a single socket, and an application-layer ping keepalive. Subscription handles stay valid across reconnects -- the underlying server-side sub-id is swapped automatically.
+
+```zig
+const eth = @import("eth");
+
+const client = try eth.ws_client.WsClient.connect(allocator, "wss://mainnet.example.com/ws", .{});
+defer client.deinit();
+
+const heads = try client.subscribe(.{ .new_heads = {} });
+const transfers = try client.subscribe(.{ .logs = .{
+    .address = usdc_address,
+    .topics = &.{transfer_event_topic},
+} });
+
+while (true) {
+    const event = try client.next();
+    defer allocator.free(event.payload);
+    if (event.sub == heads) {
+        const header = try eth.subscription.parseBlockFromNotification(allocator, event.payload);
+        // ... handle new block
+    } else if (event.sub == transfers) {
+        const log = try eth.subscription.parseLogFromNotification(allocator, event.payload);
+        // ... handle Transfer log
+    }
+}
+```
+
+Lower-level building blocks remain available: `ws_transport.WsTransport` for raw frames and `ws_transport.connectWithReconnect()` for a callback-style reconnect loop without subscription state.
+
 ## Built with eth.zig
 
 Real production bots and SDKs built on eth.zig:
@@ -193,7 +224,7 @@ cd examples && zig build && ./zig-out/bin/01_derive_address
 | **Crypto** | `secp256k1`, `signer`, `signature`, `keccak`, `eip155` | ECDSA signing (RFC 6979), Keccak-256, EIP-155 |
 | **Types** | `transaction`, `receipt`, `block`, `blob`, `access_list` | Legacy, EIP-2930, EIP-1559, EIP-4844 transactions |
 | **Accounts** | `mnemonic`, `hd_wallet` | BIP-32/39/44 HD wallets and mnemonic generation |
-| **Transport** | `http_transport`, `ws_transport`, `sse_transport`, `json_rpc`, `provider`, `subscription` | HTTP, WebSocket, and SSE transports |
+| **Transport** | `http_transport`, `ws_transport`, `sse_transport`, `json_rpc`, `provider`, `subscription`, `ws_client` | HTTP, WebSocket, and SSE transports; resilient WS client with auto-reconnect |
 | **ENS** | `ens_namehash`, `ens_resolver`, `ens_reverse` | ENS name resolution and reverse lookup |
 | **Client** | `wallet`, `contract`, `multicall`, `event`, `erc20`, `erc721` | Signing wallet, contract interaction, Multicall3, token wrappers |
 | **Standards** | `eip712`, `abi_json` | EIP-712 typed data signing, Solidity JSON ABI parsing |
@@ -216,6 +247,7 @@ cd examples && zig build && ./zig-out/bin/01_derive_address
 | BIP-32/39/44 HD wallets | Complete |
 | HTTP transport | Complete |
 | WebSocket transport (with TLS) | Complete |
+| Resilient WS client (auto-reconnect + resubscribe + keepalive) | Complete |
 | JSON-RPC provider (24+ methods) | Complete |
 | ENS resolution (forward + reverse) | Complete |
 | Contract read/write helpers | Complete |

--- a/src/root.zig
+++ b/src/root.zig
@@ -36,6 +36,7 @@ pub const http_transport = @import("http_transport.zig");
 pub const ws_transport = @import("ws_transport.zig");
 pub const sse_transport = @import("sse_transport.zig");
 pub const subscription = @import("subscription.zig");
+pub const ws_client = @import("ws_client.zig");
 pub const provider = @import("provider.zig");
 pub const retry_provider = @import("retry_provider.zig");
 pub const RetryingProvider = retry_provider.RetryingProvider;
@@ -109,6 +110,7 @@ test {
     _ = @import("ws_transport.zig");
     _ = @import("sse_transport.zig");
     _ = @import("subscription.zig");
+    _ = @import("ws_client.zig");
     _ = @import("provider.zig");
     _ = @import("retry_provider.zig");
     // Layer 7: Client

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -354,23 +354,54 @@ fn skipWs(json: []const u8, idx: usize) usize {
     return i;
 }
 
+/// Return true if `idx` is inside an open JSON string starting from the
+/// beginning of `json`. This walks character-by-character and is therefore
+/// O(idx); the call sites do this lazily only when needed (which is rare
+/// in practice -- only when a key-shaped substring appears as a false
+/// match before the real key).
+fn isInsideString(json: []const u8, idx: usize) bool {
+    const limit = @min(idx, json.len);
+    var in_string = false;
+    var i: usize = 0;
+    while (i < limit) : (i += 1) {
+        const c = json[i];
+        if (in_string and c == '\\') {
+            // Skip the next character (escape sequence).
+            i += 1;
+            continue;
+        }
+        if (c == '"') in_string = !in_string;
+    }
+    return in_string;
+}
+
 /// Find the first occurrence of `key_quoted` (e.g. `"result"`) and advance
 /// past the trailing colon and any surrounding whitespace. Returns the
 /// index of the first character of the value, or null if no such pattern
 /// exists.
+///
+/// This skips false matches in two situations:
+///   1. The substring is followed by something other than (optional ws +
+///      colon + optional ws), meaning it is not a key.
+///   2. The substring's opening quote is itself inside an open string
+///      value (e.g. an error message containing the literal text
+///      `"result":"..."`). `isInsideString` performs the check.
 fn findKeyValueStart(json: []const u8, key_quoted: []const u8) ?usize {
     var search_from: usize = 0;
     while (search_from < json.len) {
         const rel = std.mem.indexOf(u8, json[search_from..], key_quoted) orelse return null;
-        const key_end = search_from + rel + key_quoted.len;
-        var i = skipWs(json, key_end);
-        if (i < json.len and json[i] == ':') {
-            i = skipWs(json, i + 1);
-            return i;
+        const key_start = search_from + rel;
+        const key_end = key_start + key_quoted.len;
+        if (!isInsideString(json, key_start)) {
+            var i = skipWs(json, key_end);
+            if (i < json.len and json[i] == ':') {
+                i = skipWs(json, i + 1);
+                return i;
+            }
         }
-        // Found the substring but it was not a key (e.g. it appeared inside
-        // a value). Skip past this match and keep looking.
-        search_from = search_from + rel + key_quoted.len;
+        // Not a key, or the key text appeared inside a value. Skip past
+        // this match and keep looking.
+        search_from = key_end;
     }
     return null;
 }
@@ -723,4 +754,31 @@ test "extractResultString - skips key found inside a value" {
     const result = try extractResultString(allocator, json);
     defer allocator.free(result);
     try std.testing.expectEqualStrings("0xreal", result);
+}
+
+test "extractResultString - skips fake key:value embedded in a string" {
+    // The error message embeds the literal text `"result":"fake"`, which
+    // looks like a key-value pair but is inside an open string. The real
+    // `result` key follows.
+    const allocator = std.testing.allocator;
+    const json =
+        "{\"jsonrpc\":\"2.0\",\"id\":1," ++
+        "\"error\":\"got \\\"result\\\":\\\"fake\\\" from upstream\"," ++
+        "\"result\":\"0xreal\"}";
+    const result = try extractResultString(allocator, json);
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("0xreal", result);
+}
+
+test "isInsideString - basic" {
+    // Position 0 is before any string.
+    try std.testing.expect(!isInsideString("\"hi\"", 0));
+    // Position 1 is inside "hi".
+    try std.testing.expect(isInsideString("\"hi\"", 1));
+    // Position 4 is after "hi".
+    try std.testing.expect(!isInsideString("\"hi\"", 4));
+    // Escaped quotes inside a string do not close the string.
+    try std.testing.expect(isInsideString("\"a\\\"b\"", 3));
+    // Backslash before any string is not a special character.
+    try std.testing.expect(!isInsideString("\\", 1));
 }

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -337,24 +337,53 @@ pub fn formatHash(hash: [32]u8) [66]u8 {
 
 // ---------------------------------------------------------------------------
 // JSON parsing helpers (minimal, no full JSON parser)
+//
+// These scanners are deliberately not a full JSON parser. They locate a
+// `"key" <ws>? : <ws>? value` pattern by string match. JSON spec allows
+// arbitrary whitespace around the colon, so each scanner skips spaces and
+// tabs (the only whitespace likely on the wire) on either side.
 // ---------------------------------------------------------------------------
 
-/// Extract a string value from a "result":"..." pattern in a JSON response.
+fn isJsonWs(c: u8) bool {
+    return c == ' ' or c == '\t' or c == '\r' or c == '\n';
+}
+
+fn skipWs(json: []const u8, idx: usize) usize {
+    var i = idx;
+    while (i < json.len and isJsonWs(json[i])) : (i += 1) {}
+    return i;
+}
+
+/// Find the first occurrence of `key_quoted` (e.g. `"result"`) and advance
+/// past the trailing colon and any surrounding whitespace. Returns the
+/// index of the first character of the value, or null if no such pattern
+/// exists.
+fn findKeyValueStart(json: []const u8, key_quoted: []const u8) ?usize {
+    var search_from: usize = 0;
+    while (search_from < json.len) {
+        const rel = std.mem.indexOf(u8, json[search_from..], key_quoted) orelse return null;
+        const key_end = search_from + rel + key_quoted.len;
+        var i = skipWs(json, key_end);
+        if (i < json.len and json[i] == ':') {
+            i = skipWs(json, i + 1);
+            return i;
+        }
+        // Found the substring but it was not a key (e.g. it appeared inside
+        // a value). Skip past this match and keep looking.
+        search_from = search_from + rel + key_quoted.len;
+    }
+    return null;
+}
+
+/// Extract a string value from a "result": "..." pattern in a JSON response.
+/// Tolerant of whitespace around the colon.
 /// Caller owns the returned memory.
 pub fn extractResultString(allocator: std.mem.Allocator, json: []const u8) ![]u8 {
-    // Look for "result":" pattern
-    const needle = "\"result\":\"";
-    const start = std.mem.indexOf(u8, json, needle) orelse return error.InvalidResponse;
-    const value_start = start + needle.len;
-
-    // Find closing quote
-    const value_end = if (value_start < json.len)
-        if (std.mem.indexOfScalar(u8, json[value_start..], '"')) |idx| idx + value_start else null
-    else
-        null;
-    const end = value_end orelse return error.InvalidResponse;
-
-    const value = json[value_start..end];
+    const value_start = findKeyValueStart(json, "\"result\"") orelse return error.InvalidResponse;
+    if (value_start >= json.len or json[value_start] != '"') return error.InvalidResponse;
+    const string_start = value_start + 1;
+    const rel_end = std.mem.indexOfScalar(u8, json[string_start..], '"') orelse return error.InvalidResponse;
+    const value = json[string_start .. string_start + rel_end];
     const result = try allocator.alloc(u8, value.len);
     @memcpy(result, value);
     return result;
@@ -362,19 +391,9 @@ pub fn extractResultString(allocator: std.mem.Allocator, json: []const u8) ![]u8
 
 /// Check if a JSON message is a subscription notification for the given ID.
 pub fn isSubscriptionNotification(json: []const u8, subscription_id: []const u8) bool {
-    // Must contain "eth_subscription" method
     if (std.mem.indexOf(u8, json, "\"eth_subscription\"") == null) return false;
-
-    // Must contain our subscription ID
-    // Look for "subscription":"<id>" pattern
-    const needle_prefix = "\"subscription\":\"";
-    const prefix_pos = std.mem.indexOf(u8, json, needle_prefix) orelse return false;
-    const id_start = prefix_pos + needle_prefix.len;
-
-    if (id_start + subscription_id.len > json.len) return false;
-    const candidate = json[id_start .. id_start + subscription_id.len];
-
-    return std.mem.eql(u8, candidate, subscription_id);
+    const id = getSubscriptionId(json) orelse return false;
+    return std.mem.eql(u8, id, subscription_id);
 }
 
 /// Return a slice into `json` containing the subscription id from an
@@ -383,9 +402,9 @@ pub fn isSubscriptionNotification(json: []const u8, subscription_id: []const u8)
 /// its lifetime.
 pub fn getSubscriptionId(json: []const u8) ?[]const u8 {
     if (std.mem.indexOf(u8, json, "\"eth_subscription\"") == null) return null;
-    const needle_prefix = "\"subscription\":\"";
-    const prefix_pos = std.mem.indexOf(u8, json, needle_prefix) orelse return null;
-    const id_start = prefix_pos + needle_prefix.len;
+    const value_start = findKeyValueStart(json, "\"subscription\"") orelse return null;
+    if (value_start >= json.len or json[value_start] != '"') return null;
+    const id_start = value_start + 1;
     const rel_end = std.mem.indexOfScalar(u8, json[id_start..], '"') orelse return null;
     return json[id_start .. id_start + rel_end];
 }
@@ -394,15 +413,11 @@ pub fn getSubscriptionId(json: []const u8) ?[]const u8 {
 /// Returns null if the field is absent or the value is not a base-10 integer.
 /// This is a fast path for matching responses without full JSON parsing.
 pub fn extractResponseId(json: []const u8) ?u64 {
-    const needle = "\"id\":";
-    const start = std.mem.indexOf(u8, json, needle) orelse return null;
-    var i = start + needle.len;
-    // Skip optional whitespace
-    while (i < json.len and (json[i] == ' ' or json[i] == '\t')) : (i += 1) {}
-    const num_start = i;
+    const value_start = findKeyValueStart(json, "\"id\"") orelse return null;
+    var i = value_start;
     while (i < json.len and json[i] >= '0' and json[i] <= '9') : (i += 1) {}
-    if (i == num_start) return null;
-    return std.fmt.parseInt(u64, json[num_start..i], 10) catch null;
+    if (i == value_start) return null;
+    return std.fmt.parseInt(u64, json[value_start..i], 10) catch null;
 }
 
 // ============================================================================
@@ -674,4 +689,38 @@ test "extractResponseId - missing id" {
 test "extractResponseId - non-numeric id" {
     const json = "{\"jsonrpc\":\"2.0\",\"id\":null,\"result\":1}";
     try std.testing.expect(extractResponseId(json) == null);
+}
+
+test "extractResultString - whitespace around colon" {
+    const allocator = std.testing.allocator;
+    const json = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\" : \"0xabc\"}";
+    const result = try extractResultString(allocator, json);
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("0xabc", result);
+}
+
+test "getSubscriptionId - whitespace around colon" {
+    const json =
+        "{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscription\"," ++
+        "\"params\":{ \"subscription\" : \"0xWS\", \"result\":{}}}";
+    const id = getSubscriptionId(json) orelse return error.TestExpectedSome;
+    try std.testing.expectEqualStrings("0xWS", id);
+}
+
+test "extractResponseId - whitespace before colon" {
+    const json = "{\"jsonrpc\":\"2.0\",\"id\" : 99,\"result\":1}";
+    try std.testing.expectEqual(@as(?u64, 99), extractResponseId(json));
+}
+
+test "extractResultString - skips key found inside a value" {
+    // `"result"` appears inside the error message, but is not a key. The
+    // scanner must keep looking until it finds a real `"result":` key.
+    const allocator = std.testing.allocator;
+    const json =
+        "{\"jsonrpc\":\"2.0\",\"id\":1," ++
+        "\"description\":\"the \\\"result\\\" was unexpected\"," ++
+        "\"result\":\"0xreal\"}";
+    const result = try extractResultString(allocator, json);
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("0xreal", result);
 }

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -151,21 +151,7 @@ pub const Subscription = struct {
     pub fn nextBlock(self: *Subscription, allocator: std.mem.Allocator) !block_mod.BlockHeader {
         const raw = try self.next();
         defer self.allocator.free(raw);
-
-        const parsed = std.json.parseFromSlice(std.json.Value, allocator, raw, .{}) catch
-            return error.InvalidNotification;
-        defer parsed.deinit();
-
-        const result_val = getNotificationResult(parsed.value) orelse return error.InvalidNotification;
-
-        // Serialize result back and wrap as {"result":...} for reuse with parseBlockHeader.
-        const result_json = try std.json.stringifyAlloc(allocator, result_val, .{});
-        defer allocator.free(result_json);
-
-        const wrapped = try std.fmt.allocPrint(allocator, "{{\"result\":{s}}}", .{result_json});
-        defer allocator.free(wrapped);
-
-        return (try provider_mod.parseBlockHeader(allocator, wrapped)) orelse error.NullResult;
+        return parseBlockFromNotification(allocator, raw);
     }
 
     /// For logs subscriptions: parse and return the next log.
@@ -173,32 +159,69 @@ pub const Subscription = struct {
     pub fn nextLog(self: *Subscription, allocator: std.mem.Allocator) !receipt_mod.Log {
         const raw = try self.next();
         defer self.allocator.free(raw);
-
-        const parsed = std.json.parseFromSlice(std.json.Value, allocator, raw, .{}) catch
-            return error.InvalidNotification;
-        defer parsed.deinit();
-
-        const result_val = getNotificationResult(parsed.value) orelse return error.InvalidNotification;
-        if (result_val != .object) return error.InvalidNotification;
-
-        return try provider_mod.parseSingleLog(allocator, result_val.object);
+        return parseLogFromNotification(allocator, raw);
     }
 
     /// For new_pending_transactions subscriptions: return the next transaction hash.
     pub fn nextTxHash(self: *Subscription) ![32]u8 {
         const raw = try self.next();
         defer self.allocator.free(raw);
-
-        const parsed = std.json.parseFromSlice(std.json.Value, self.allocator, raw, .{}) catch
-            return error.InvalidNotification;
-        defer parsed.deinit();
-
-        const result_val = getNotificationResult(parsed.value) orelse return error.InvalidNotification;
-        if (result_val != .string) return error.InvalidNotification;
-
-        return primitives.hashFromHex(result_val.string) catch error.InvalidNotification;
+        return parseTxHashFromNotification(self.allocator, raw);
     }
 };
+
+// ---------------------------------------------------------------------------
+// Free-function notification parsers
+//
+// These are the raw building blocks for parsing eth_subscription notifications.
+// Subscription's nextBlock/nextLog/nextTxHash methods are thin wrappers around
+// them, and ws_client.WsClient uses the same parsers without needing a
+// Subscription instance.
+// ---------------------------------------------------------------------------
+
+/// Parse a `newHeads` notification payload into a BlockHeader.
+/// Caller owns the returned BlockHeader's allocated fields (extra_data).
+pub fn parseBlockFromNotification(allocator: std.mem.Allocator, raw: []const u8) !block_mod.BlockHeader {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, raw, .{}) catch
+        return error.InvalidNotification;
+    defer parsed.deinit();
+
+    const result_val = getNotificationResult(parsed.value) orelse return error.InvalidNotification;
+
+    // Serialize result back and wrap as {"result":...} for reuse with parseBlockHeader.
+    const result_json = try std.json.stringifyAlloc(allocator, result_val, .{});
+    defer allocator.free(result_json);
+
+    const wrapped = try std.fmt.allocPrint(allocator, "{{\"result\":{s}}}", .{result_json});
+    defer allocator.free(wrapped);
+
+    return (try provider_mod.parseBlockHeader(allocator, wrapped)) orelse error.NullResult;
+}
+
+/// Parse a `logs` notification payload into a Log.
+/// Caller owns the returned Log's allocated fields (topics, data).
+pub fn parseLogFromNotification(allocator: std.mem.Allocator, raw: []const u8) !receipt_mod.Log {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, raw, .{}) catch
+        return error.InvalidNotification;
+    defer parsed.deinit();
+
+    const result_val = getNotificationResult(parsed.value) orelse return error.InvalidNotification;
+    if (result_val != .object) return error.InvalidNotification;
+
+    return try provider_mod.parseSingleLog(allocator, result_val.object);
+}
+
+/// Parse a `newPendingTransactions` notification payload into a 32-byte tx hash.
+pub fn parseTxHashFromNotification(allocator: std.mem.Allocator, raw: []const u8) ![32]u8 {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, raw, .{}) catch
+        return error.InvalidNotification;
+    defer parsed.deinit();
+
+    const result_val = getNotificationResult(parsed.value) orelse return error.InvalidNotification;
+    if (result_val != .string) return error.InvalidNotification;
+
+    return primitives.hashFromHex(result_val.string) catch error.InvalidNotification;
+}
 
 // ---------------------------------------------------------------------------
 // Notification parsing helpers
@@ -208,7 +231,7 @@ pub const Subscription = struct {
 /// Notification format: {"jsonrpc":"2.0","method":"eth_subscription",
 ///                       "params":{"subscription":"0x...","result":{...}}}
 /// Returns null if the JSON does not match the expected notification structure.
-fn getNotificationResult(root: std.json.Value) ?std.json.Value {
+pub fn getNotificationResult(root: std.json.Value) ?std.json.Value {
     if (root != .object) return null;
     const params_val = root.object.get("params") orelse return null;
     if (params_val != .object) return null;
@@ -318,7 +341,7 @@ pub fn formatHash(hash: [32]u8) [66]u8 {
 
 /// Extract a string value from a "result":"..." pattern in a JSON response.
 /// Caller owns the returned memory.
-fn extractResultString(allocator: std.mem.Allocator, json: []const u8) ![]u8 {
+pub fn extractResultString(allocator: std.mem.Allocator, json: []const u8) ![]u8 {
     // Look for "result":" pattern
     const needle = "\"result\":\"";
     const start = std.mem.indexOf(u8, json, needle) orelse return error.InvalidResponse;
@@ -338,7 +361,7 @@ fn extractResultString(allocator: std.mem.Allocator, json: []const u8) ![]u8 {
 }
 
 /// Check if a JSON message is a subscription notification for the given ID.
-fn isSubscriptionNotification(json: []const u8, subscription_id: []const u8) bool {
+pub fn isSubscriptionNotification(json: []const u8, subscription_id: []const u8) bool {
     // Must contain "eth_subscription" method
     if (std.mem.indexOf(u8, json, "\"eth_subscription\"") == null) return false;
 
@@ -352,6 +375,34 @@ fn isSubscriptionNotification(json: []const u8, subscription_id: []const u8) boo
     const candidate = json[id_start .. id_start + subscription_id.len];
 
     return std.mem.eql(u8, candidate, subscription_id);
+}
+
+/// Return a slice into `json` containing the subscription id from an
+/// eth_subscription notification, or null if `json` is not such a
+/// notification. The returned slice borrows `json` and is only valid for
+/// its lifetime.
+pub fn getSubscriptionId(json: []const u8) ?[]const u8 {
+    if (std.mem.indexOf(u8, json, "\"eth_subscription\"") == null) return null;
+    const needle_prefix = "\"subscription\":\"";
+    const prefix_pos = std.mem.indexOf(u8, json, needle_prefix) orelse return null;
+    const id_start = prefix_pos + needle_prefix.len;
+    const rel_end = std.mem.indexOfScalar(u8, json[id_start..], '"') orelse return null;
+    return json[id_start .. id_start + rel_end];
+}
+
+/// Extract a JSON-RPC `id` integer from a response payload by string match.
+/// Returns null if the field is absent or the value is not a base-10 integer.
+/// This is a fast path for matching responses without full JSON parsing.
+pub fn extractResponseId(json: []const u8) ?u64 {
+    const needle = "\"id\":";
+    const start = std.mem.indexOf(u8, json, needle) orelse return null;
+    var i = start + needle.len;
+    // Skip optional whitespace
+    while (i < json.len and (json[i] == ' ' or json[i] == '\t')) : (i += 1) {}
+    const num_start = i;
+    while (i < json.len and json[i] >= '0' and json[i] <= '9') : (i += 1) {}
+    if (i == num_start) return null;
+    return std.fmt.parseInt(u64, json[num_start..i], 10) catch null;
 }
 
 // ============================================================================
@@ -583,4 +634,44 @@ test "Subscription struct layout" {
 
     // Prevent deinit from freeing non-allocated memory
     sub.id = "";
+}
+
+test "getSubscriptionId - matching" {
+    const json =
+        "{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscription\"," ++
+        "\"params\":{\"subscription\":\"0xabcdef\",\"result\":{}}}";
+    const id = getSubscriptionId(json) orelse return error.TestExpectedSome;
+    try std.testing.expectEqualStrings("0xabcdef", id);
+}
+
+test "getSubscriptionId - not a notification" {
+    const json = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"0xabc\"}";
+    try std.testing.expect(getSubscriptionId(json) == null);
+}
+
+test "getSubscriptionId - missing subscription field" {
+    const json =
+        "{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscription\"," ++
+        "\"params\":{\"result\":{}}}";
+    try std.testing.expect(getSubscriptionId(json) == null);
+}
+
+test "extractResponseId - simple" {
+    const json = "{\"jsonrpc\":\"2.0\",\"id\":42,\"result\":\"0xabc\"}";
+    try std.testing.expectEqual(@as(?u64, 42), extractResponseId(json));
+}
+
+test "extractResponseId - whitespace tolerant" {
+    const json = "{\"jsonrpc\":\"2.0\",\"id\": 7,\"result\":1}";
+    try std.testing.expectEqual(@as(?u64, 7), extractResponseId(json));
+}
+
+test "extractResponseId - missing id" {
+    const json = "{\"jsonrpc\":\"2.0\",\"method\":\"x\"}";
+    try std.testing.expect(extractResponseId(json) == null);
+}
+
+test "extractResponseId - non-numeric id" {
+    const json = "{\"jsonrpc\":\"2.0\",\"id\":null,\"result\":1}";
+    try std.testing.expect(extractResponseId(json) == null);
 }

--- a/src/ws_client.zig
+++ b/src/ws_client.zig
@@ -71,6 +71,10 @@ pub const Error = error{
     UnsubscribeFailed,
     InvalidNotification,
     InvalidResponse,
+    /// The request was sent but the connection dropped before a response
+    /// arrived. The server may or may not have processed it; the caller
+    /// must decide whether to retry.
+    RequestInterrupted,
     OutOfMemory,
 };
 
@@ -173,7 +177,11 @@ pub const WsClient = struct {
         const params_json = try subscription.buildSubscribeParams(self.allocator, owned);
         defer self.allocator.free(params_json);
 
-        const response = self.request(json_rpc.Method.eth_subscribe, params_json) catch
+        // eth_subscribe is idempotent at the protocol level (a duplicate
+        // subscribe just creates a second sub on the server, which is
+        // harmless if the original was lost to a disconnect), so we use
+        // the replay-safe internal request path.
+        const response = self.requestReplay(json_rpc.Method.eth_subscribe, params_json) catch
             return error.SubscribeFailed;
         defer self.allocator.free(response);
 
@@ -208,6 +216,11 @@ pub const WsClient = struct {
         }
         if (idx_opt) |idx| _ = self.subs.orderedRemove(idx);
 
+        // Drop any queued notifications that point at this sub. Without
+        // this purge, a subsequent next() would return an Event whose
+        // `sub` field is a dangling pointer.
+        self.dropPending(sub);
+
         // Best-effort eth_unsubscribe.
         const params_json = std.fmt.allocPrint(self.allocator, "[\"{s}\"]", .{sub.server_id}) catch {
             self.freeSubscription(sub);
@@ -215,7 +228,9 @@ pub const WsClient = struct {
         };
         defer self.allocator.free(params_json);
 
-        const response = self.request(json_rpc.Method.eth_unsubscribe, params_json) catch {
+        // eth_unsubscribe is idempotent (the server tolerates an unknown
+        // sub-id by returning false), so use the replay-safe internal path.
+        const response = self.requestReplay(json_rpc.Method.eth_unsubscribe, params_json) catch {
             self.freeSubscription(sub);
             return;
         };
@@ -253,9 +268,37 @@ pub const WsClient = struct {
         }
     }
 
-    /// Send a JSON-RPC request and wait for the matching response. Sub
-    /// notifications received while waiting are queued for `next()`.
+    /// Send a JSON-RPC request and wait for the matching response.
+    ///
+    /// Sub notifications received while waiting are queued for `next()`.
+    ///
+    /// **Idempotency:** if the connection drops AFTER the request was sent
+    /// but BEFORE the response was read, this method returns
+    /// `error.RequestInterrupted` instead of silently re-sending. The server
+    /// may have already processed the original request; only the caller
+    /// knows whether the method is safe to retry. Pre-send failures (the
+    /// transport was already dead) trigger a transparent reconnect and a
+    /// single retry, since the request has not yet been observed by any
+    /// server.
     pub fn request(self: *WsClient, method: []const u8, params_json: []const u8) ![]u8 {
+        return self.requestImpl(method, params_json, .no_replay);
+    }
+
+    /// Internal: like `request`, but replays the request on post-send
+    /// disconnect. Use only for methods that are safe to issue twice
+    /// (eth_subscribe, eth_unsubscribe).
+    fn requestReplay(self: *WsClient, method: []const u8, params_json: []const u8) ![]u8 {
+        return self.requestImpl(method, params_json, .replay);
+    }
+
+    const ReplayPolicy = enum { no_replay, replay };
+
+    fn requestImpl(
+        self: *WsClient,
+        method: []const u8,
+        params_json: []const u8,
+        replay: ReplayPolicy,
+    ) ![]u8 {
         const id = self.next_id;
         self.next_id += 1;
 
@@ -266,6 +309,8 @@ pub const WsClient = struct {
         );
         defer self.allocator.free(req);
 
+        // Pre-send: the request has never been sent on the wire, so
+        // reconnecting and retrying the send is always safe.
         try self.sendOrReconnect(req);
 
         while (true) {
@@ -274,11 +319,18 @@ pub const WsClient = struct {
             const frame = self.readFrameWithKeepalive() catch |err| switch (err) {
                 error.Disconnected => return error.Disconnected,
                 error.Closed => return error.Closed,
-                else => {
-                    try self.beginReconnect();
-                    // After reconnect the original request id is gone. Re-send.
-                    try self.sendOrReconnect(req);
-                    continue;
+                else => switch (replay) {
+                    .no_replay => {
+                        // Reconnect for future calls but do NOT replay this
+                        // request -- the server may have processed it.
+                        self.beginReconnect() catch {};
+                        return error.RequestInterrupted;
+                    },
+                    .replay => {
+                        try self.beginReconnect();
+                        try self.sendOrReconnect(req);
+                        continue;
+                    },
                 },
             };
 
@@ -467,6 +519,21 @@ pub const WsClient = struct {
         self.allocator.free(sub.server_id);
         freeOwnedParams(self.allocator, sub.params);
         self.allocator.destroy(sub);
+    }
+
+    /// Remove any queued events whose `sub` pointer matches `target`,
+    /// freeing their payloads. Called from `unsubscribe` to prevent
+    /// dangling pointers in the pending queue.
+    fn dropPending(self: *WsClient, target: *Subscription) void {
+        var i: usize = 0;
+        while (i < self.pending.items.len) {
+            if (self.pending.items[i].sub == target) {
+                const ev = self.pending.orderedRemove(i);
+                self.allocator.free(ev.payload);
+            } else {
+                i += 1;
+            }
+        }
     }
 };
 
@@ -745,6 +812,27 @@ test "queueNotification - rejects unknown sub_id" {
     defer alloc.free(f);
     try std.testing.expect(!try client.queueNotification(f));
     try std.testing.expectEqual(@as(usize, 0), client.pending.items.len);
+}
+
+test "dropPending - removes only matching events" {
+    const alloc = std.testing.allocator;
+    var client = testStubClient(alloc);
+    defer freeStubClient(&client);
+
+    const sub_a = try registerStubSubscription(&client, "0xaaa");
+    const sub_b = try registerStubSubscription(&client, "0xbbb");
+
+    // Queue: A, B, A. After dropPending(sub_a) we expect just B.
+    const f1 = try fakeNotification(alloc, "0xaaa");
+    const f2 = try fakeNotification(alloc, "0xbbb");
+    const f3 = try fakeNotification(alloc, "0xaaa");
+    try std.testing.expect(try client.queueNotification(f1));
+    try std.testing.expect(try client.queueNotification(f2));
+    try std.testing.expect(try client.queueNotification(f3));
+
+    client.dropPending(sub_a);
+    try std.testing.expectEqual(@as(usize, 1), client.pending.items.len);
+    try std.testing.expect(client.pending.items[0].sub == sub_b);
 }
 
 test "subscription registry - server_id remap preserves handle" {

--- a/src/ws_client.zig
+++ b/src/ws_client.zig
@@ -1,0 +1,772 @@
+const std = @import("std");
+const ws_transport = @import("ws_transport.zig");
+const subscription = @import("subscription.zig");
+const json_rpc = @import("json_rpc.zig");
+
+const WsTransport = ws_transport.WsTransport;
+const Opcode = ws_transport.Opcode;
+const SubscriptionParams = subscription.SubscriptionParams;
+const SubscriptionType = subscription.SubscriptionType;
+const LogSubscriptionParams = subscription.LogSubscriptionParams;
+
+/// Resilient WebSocket client for Ethereum JSON-RPC.
+///
+/// Wraps `WsTransport` with three additions a production bot needs but that
+/// the transport-level API does not provide:
+///
+///   1. Transparent reconnect with exponential backoff + jitter. When the
+///      socket drops, `next()` and `request()` automatically rebuild the
+///      transport and re-issue every active subscription before returning.
+///   2. Multiplexed subscriptions over a single connection. Multiple
+///      `Subscription` handles can coexist; notifications are dispatched to
+///      the right handle and never silently dropped.
+///   3. Application-layer keepalive. If no frames arrive for
+///      `ping_interval_ms`, a ping is sent. If no pong arrives within
+///      `pong_timeout_ms`, the connection is treated as dead.
+///
+/// `WsClient` is single-threaded by design. All network I/O happens
+/// synchronously inside `next()` / `request()` / `subscribe()` /
+/// `unsubscribe()`. There are no background threads, locks, or callbacks.
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+pub const Opts = struct {
+    /// Initial backoff in milliseconds before the first reconnect attempt.
+    initial_backoff_ms: u64 = 1_000,
+    /// Hard cap on backoff.
+    max_backoff_ms: u64 = 30_000,
+    /// Maximum reconnect attempts before `next()` returns `error.Disconnected`.
+    /// 0 means retry forever.
+    max_retries: u32 = 0,
+    /// Send a ping if no frame has been received for this long. 0 disables.
+    ping_interval_ms: u64 = 30_000,
+    /// If a pong is not received within this long after the ping, the
+    /// connection is treated as dead and reconnect is triggered.
+    pong_timeout_ms: u64 = 10_000,
+    /// Backoff jitter as a percentage, applied symmetrically. With 20%, a
+    /// 1000 ms backoff becomes a uniform random value in [800, 1200] ms.
+    jitter_pct: u8 = 20,
+    /// Optional callback invoked before each reconnect attempt (after the
+    /// backoff sleep, before the connect call).
+    on_reconnect: ?*const fn (attempt: u32, backoff_ms: u64) void = null,
+};
+
+pub const Event = struct {
+    /// The subscription this notification belongs to.
+    sub: *Subscription,
+    /// Raw JSON notification payload. Caller owns this memory and must free
+    /// it with the same allocator passed to `WsClient.connect`.
+    payload: []u8,
+};
+
+pub const Error = error{
+    ConnectionFailed,
+    /// `max_retries` exhausted without a successful reconnect.
+    Disconnected,
+    /// `deinit()` was called while a read was in flight.
+    Closed,
+    SubscribeFailed,
+    UnsubscribeFailed,
+    InvalidNotification,
+    InvalidResponse,
+    OutOfMemory,
+};
+
+pub const Subscription = struct {
+    /// Stable identifier across reconnects. Useful in logs.
+    handle: u64,
+    /// Caller-owned deep copy of the original params. Replayed on every
+    /// reconnect to re-issue `eth_subscribe`.
+    params: SubscriptionParams,
+    /// Current sub-id from the node. Replaced on every reconnect.
+    /// Owned by the registry.
+    server_id: []u8,
+    /// Back-pointer to the owning client.
+    client: *WsClient,
+};
+
+pub const WsClient = struct {
+    allocator: std.mem.Allocator,
+    /// Owned copy of the URL used for reconnects.
+    url: []u8,
+    transport: ?WsTransport,
+    subs: std.ArrayList(*Subscription),
+    /// FIFO of notifications that arrived while a `request()` was waiting
+    /// for its matching response. `next()` drains these first.
+    pending: std.ArrayList(Event),
+    next_handle: u64,
+    next_id: u64,
+    opts: Opts,
+    state: State,
+    /// `std.time.milliTimestamp()` of the last received frame.
+    last_activity_ms: i64,
+    /// Sentinel for an in-flight ping.
+    pending_pong: bool,
+    ping_sent_ms: i64,
+    rng: std.Random.DefaultPrng,
+
+    pub const State = enum { connected, reconnecting, closed };
+
+    /// Open a resilient WebSocket client.
+    /// `connect()` itself is NOT retried; if the very first connect fails,
+    /// the call returns `error.ConnectionFailed`.
+    pub fn connect(allocator: std.mem.Allocator, url: []const u8, opts: Opts) !*WsClient {
+        const self = try allocator.create(WsClient);
+        errdefer allocator.destroy(self);
+
+        const url_copy = try allocator.dupe(u8, url);
+        errdefer allocator.free(url_copy);
+
+        const transport = WsTransport.connect(allocator, url) catch return error.ConnectionFailed;
+
+        self.* = .{
+            .allocator = allocator,
+            .url = url_copy,
+            .transport = transport,
+            .subs = .empty,
+            .pending = .empty,
+            .next_handle = 1,
+            .next_id = 1,
+            .opts = opts,
+            .state = .connected,
+            .last_activity_ms = std.time.milliTimestamp(),
+            .pending_pong = false,
+            .ping_sent_ms = 0,
+            .rng = std.Random.DefaultPrng.init(@bitCast(std.time.milliTimestamp())),
+        };
+        return self;
+    }
+
+    /// Close the transport (best-effort) and free all resources.
+    pub fn deinit(self: *WsClient) void {
+        self.state = .closed;
+        if (self.transport) |*t| t.close();
+        self.transport = null;
+
+        for (self.subs.items) |sub| {
+            self.allocator.free(sub.server_id);
+            freeOwnedParams(self.allocator, sub.params);
+            self.allocator.destroy(sub);
+        }
+        self.subs.deinit(self.allocator);
+
+        for (self.pending.items) |ev| {
+            self.allocator.free(ev.payload);
+        }
+        self.pending.deinit(self.allocator);
+
+        self.allocator.free(self.url);
+        self.allocator.destroy(self);
+    }
+
+    /// Subscribe via `eth_subscribe` and register the subscription so it is
+    /// re-issued automatically on reconnect.
+    pub fn subscribe(self: *WsClient, params: SubscriptionParams) !*Subscription {
+        const owned = try cloneParams(self.allocator, params);
+        errdefer freeOwnedParams(self.allocator, owned);
+
+        const sub = try self.allocator.create(Subscription);
+        errdefer self.allocator.destroy(sub);
+
+        const params_json = try subscription.buildSubscribeParams(self.allocator, owned);
+        defer self.allocator.free(params_json);
+
+        const response = self.request(json_rpc.Method.eth_subscribe, params_json) catch
+            return error.SubscribeFailed;
+        defer self.allocator.free(response);
+
+        const server_id = subscription.extractResultString(self.allocator, response) catch
+            return error.InvalidResponse;
+        errdefer self.allocator.free(server_id);
+
+        sub.* = .{
+            .handle = self.next_handle,
+            .params = owned,
+            .server_id = server_id,
+            .client = self,
+        };
+        self.next_handle += 1;
+
+        try self.subs.append(self.allocator, sub);
+        return sub;
+    }
+
+    /// Unsubscribe and free the handle. The `eth_unsubscribe` call is
+    /// best-effort; failures do not propagate, since the server will garbage
+    /// collect its end on disconnect anyway.
+    pub fn unsubscribe(self: *WsClient, sub: *Subscription) !void {
+        // Remove from registry first so a mid-call reconnect does not try to
+        // resubscribe a sub the user is tearing down.
+        var idx_opt: ?usize = null;
+        for (self.subs.items, 0..) |s, i| {
+            if (s == sub) {
+                idx_opt = i;
+                break;
+            }
+        }
+        if (idx_opt) |idx| _ = self.subs.orderedRemove(idx);
+
+        // Best-effort eth_unsubscribe.
+        const params_json = std.fmt.allocPrint(self.allocator, "[\"{s}\"]", .{sub.server_id}) catch {
+            self.freeSubscription(sub);
+            return;
+        };
+        defer self.allocator.free(params_json);
+
+        const response = self.request(json_rpc.Method.eth_unsubscribe, params_json) catch {
+            self.freeSubscription(sub);
+            return;
+        };
+        self.allocator.free(response);
+        self.freeSubscription(sub);
+    }
+
+    /// Read the next subscription notification, transparently reconnecting
+    /// and resubscribing on disconnect.
+    pub fn next(self: *WsClient) Error!Event {
+        while (true) {
+            if (self.state == .closed) return error.Closed;
+
+            // Drain queued notifications first.
+            if (self.pending.items.len > 0) {
+                return self.pending.orderedRemove(0);
+            }
+
+            const frame = self.readFrameWithKeepalive() catch |err| switch (err) {
+                error.Disconnected => return error.Disconnected,
+                error.Closed => return error.Closed,
+                else => {
+                    try self.beginReconnect();
+                    continue;
+                },
+            };
+
+            if (self.dispatch(frame)) |maybe_event| {
+                if (maybe_event) |ev| return ev;
+                // Frame was a response or unrelated; keep reading.
+                continue;
+            } else |err| {
+                return err;
+            }
+        }
+    }
+
+    /// Send a JSON-RPC request and wait for the matching response. Sub
+    /// notifications received while waiting are queued for `next()`.
+    pub fn request(self: *WsClient, method: []const u8, params_json: []const u8) ![]u8 {
+        const id = self.next_id;
+        self.next_id += 1;
+
+        const req = try std.fmt.allocPrint(
+            self.allocator,
+            "{{\"jsonrpc\":\"2.0\",\"method\":\"{s}\",\"params\":{s},\"id\":{d}}}",
+            .{ method, params_json, id },
+        );
+        defer self.allocator.free(req);
+
+        try self.sendOrReconnect(req);
+
+        while (true) {
+            if (self.state == .closed) return error.Closed;
+
+            const frame = self.readFrameWithKeepalive() catch |err| switch (err) {
+                error.Disconnected => return error.Disconnected,
+                error.Closed => return error.Closed,
+                else => {
+                    try self.beginReconnect();
+                    // After reconnect the original request id is gone. Re-send.
+                    try self.sendOrReconnect(req);
+                    continue;
+                },
+            };
+
+            if (subscription.getSubscriptionId(frame)) |_| {
+                // Notification; queue for next() and keep reading.
+                if (try self.queueNotification(frame)) {
+                    continue;
+                } else {
+                    self.allocator.free(frame);
+                    continue;
+                }
+            }
+
+            if (subscription.extractResponseId(frame)) |response_id| {
+                if (response_id == id) return frame;
+            }
+
+            // Unrelated frame; discard.
+            self.allocator.free(frame);
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    // Internal: I/O helpers
+    // ----------------------------------------------------------------------
+
+    fn sendOrReconnect(self: *WsClient, payload: []const u8) !void {
+        while (true) {
+            if (self.transport) |*t| {
+                t.sendText(payload) catch {
+                    try self.beginReconnect();
+                    continue;
+                };
+                return;
+            }
+            try self.beginReconnect();
+        }
+    }
+
+    /// Read a single data frame, sending pings and triggering reconnect on
+    /// pong timeout as needed. Returns the raw payload (caller owns).
+    fn readFrameWithKeepalive(self: *WsClient) ![]u8 {
+        while (true) {
+            if (self.transport == null) try self.beginReconnect();
+            const t = &self.transport.?;
+            const frames_before = t.frames_received;
+
+            const now = std.time.milliTimestamp();
+
+            // Pong-timeout check.
+            if (self.pending_pong and now - self.ping_sent_ms >= @as(i64, @intCast(self.opts.pong_timeout_ms))) {
+                return error.PongTimeout;
+            }
+
+            // Maybe send a fresh ping.
+            if (self.opts.ping_interval_ms != 0 and !self.pending_pong) {
+                const elapsed_idle = now - self.last_activity_ms;
+                if (elapsed_idle >= @as(i64, @intCast(self.opts.ping_interval_ms))) {
+                    var nonce: [8]u8 = undefined;
+                    std.crypto.random.bytes(&nonce);
+                    t.sendPing(&nonce) catch return error.WriteError;
+                    self.ping_sent_ms = now;
+                    self.pending_pong = true;
+                }
+            }
+
+            // Compute deadline for the next read.
+            const deadline_ms: i64 = if (self.pending_pong)
+                self.ping_sent_ms + @as(i64, @intCast(self.opts.pong_timeout_ms))
+            else if (self.opts.ping_interval_ms != 0)
+                self.last_activity_ms + @as(i64, @intCast(self.opts.ping_interval_ms))
+            else
+                std.math.maxInt(i64);
+
+            const maybe_frame = t.readMessageDeadline(deadline_ms) catch return error.ReadError;
+            if (maybe_frame) |frame| {
+                self.last_activity_ms = std.time.milliTimestamp();
+                self.pending_pong = false;
+                return frame;
+            }
+            // Timeout: if the transport saw a control frame (e.g. pong) while
+            // we were waiting for a data frame, we are still alive. Otherwise
+            // loop, which will either send a ping or trip pong-timeout.
+            if (t.frames_received != frames_before) {
+                self.last_activity_ms = std.time.milliTimestamp();
+                self.pending_pong = false;
+            }
+        }
+    }
+
+    /// Inspect a frame and either dispatch it as a sub notification or
+    /// discard it. Returns the dispatched Event if it matched a registered
+    /// subscription.
+    fn dispatch(self: *WsClient, frame: []u8) !?Event {
+        if (subscription.getSubscriptionId(frame)) |sub_id| {
+            for (self.subs.items) |s| {
+                if (std.mem.eql(u8, s.server_id, sub_id)) {
+                    return Event{ .sub = s, .payload = frame };
+                }
+            }
+            // Notification for an unknown sub-id (stale post-reconnect, etc).
+            self.allocator.free(frame);
+            return null;
+        }
+        // Not a notification (probably a stray response). Discard.
+        self.allocator.free(frame);
+        return null;
+    }
+
+    /// Like `dispatch`, but for use inside `request()` where notifications
+    /// must be queued instead of returned. Returns true if queued.
+    fn queueNotification(self: *WsClient, frame: []u8) !bool {
+        const sub_id = subscription.getSubscriptionId(frame) orelse return false;
+        for (self.subs.items) |s| {
+            if (std.mem.eql(u8, s.server_id, sub_id)) {
+                try self.pending.append(self.allocator, .{ .sub = s, .payload = frame });
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // ----------------------------------------------------------------------
+    // Internal: reconnect + resubscribe
+    // ----------------------------------------------------------------------
+
+    /// Drive the reconnect+resubscribe loop until success or `Disconnected`.
+    fn beginReconnect(self: *WsClient) !void {
+        if (self.state == .closed) return error.Closed;
+        self.state = .reconnecting;
+
+        if (self.transport) |*t| t.close();
+        self.transport = null;
+        self.pending_pong = false;
+
+        var attempt: u32 = 0;
+        while (true) {
+            const base = computeBackoffMs(self.opts, attempt);
+            const delay = applyJitter(base, self.opts.jitter_pct, self.rng.random());
+
+            if (self.opts.on_reconnect) |cb| cb(attempt, delay);
+            std.Thread.sleep(delay * std.time.ns_per_ms);
+
+            const maybe_t = WsTransport.connect(self.allocator, self.url);
+            if (maybe_t) |t_val| {
+                var t = t_val;
+                if (self.resubscribeAll(&t)) |_| {
+                    self.transport = t;
+                    self.state = .connected;
+                    self.last_activity_ms = std.time.milliTimestamp();
+                    return;
+                } else |_| {
+                    t.close();
+                }
+            } else |_| {}
+
+            attempt += 1;
+            if (self.opts.max_retries != 0 and attempt >= self.opts.max_retries) {
+                self.state = .closed;
+                return error.Disconnected;
+            }
+        }
+    }
+
+    /// Re-issue eth_subscribe for every registered subscription. On any
+    /// failure, frees any newly-allocated server_ids and returns an error so
+    /// the caller can close the transport and back off.
+    fn resubscribeAll(self: *WsClient, t: *WsTransport) !void {
+        for (self.subs.items) |sub| {
+            const params_json = try subscription.buildSubscribeParams(self.allocator, sub.params);
+            defer self.allocator.free(params_json);
+
+            const response = t.request(json_rpc.Method.eth_subscribe, params_json) catch
+                return error.SubscribeFailed;
+            defer self.allocator.free(response);
+
+            const new_id = subscription.extractResultString(self.allocator, response) catch
+                return error.InvalidResponse;
+
+            self.allocator.free(sub.server_id);
+            sub.server_id = new_id;
+        }
+    }
+
+    fn freeSubscription(self: *WsClient, sub: *Subscription) void {
+        self.allocator.free(sub.server_id);
+        freeOwnedParams(self.allocator, sub.params);
+        self.allocator.destroy(sub);
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Pure helpers (testable without I/O)
+// ---------------------------------------------------------------------------
+
+/// Compute the base backoff in milliseconds for the given attempt number.
+/// `attempt` is 0-indexed: attempt 0 returns `initial_backoff_ms`, attempt 1
+/// returns 2x that, etc. The result is clamped to `max_backoff_ms`.
+pub fn computeBackoffMs(opts: Opts, attempt: u32) u64 {
+    if (opts.initial_backoff_ms == 0) return 0;
+    // Avoid overflow when shifting: anything past 30 doublings is well
+    // beyond max_backoff_ms in any sane configuration.
+    const safe_shift: u6 = if (attempt > 30) 30 else @intCast(attempt);
+    const doubled = std.math.shl(u64, opts.initial_backoff_ms, safe_shift);
+    // shl saturates? No, it traps on overflow. Use a saturating shift:
+    const candidate = if (doubled / opts.initial_backoff_ms != @as(u64, 1) << safe_shift)
+        std.math.maxInt(u64)
+    else
+        doubled;
+    return @min(candidate, opts.max_backoff_ms);
+}
+
+/// Apply symmetric jitter to a backoff. With `pct = 20`, returns a uniform
+/// random value in `[base * 0.8, base * 1.2]`.
+pub fn applyJitter(base_ms: u64, pct: u8, rng: std.Random) u64 {
+    if (pct == 0 or base_ms == 0) return base_ms;
+    const span = (base_ms * pct) / 100;
+    if (span == 0) return base_ms;
+    const offset = rng.uintLessThan(u64, 2 * span + 1);
+    // base + offset - span, with underflow guard.
+    if (offset >= span) return base_ms + (offset - span);
+    return base_ms - (span - offset);
+}
+
+// ---------------------------------------------------------------------------
+// Param ownership helpers
+// ---------------------------------------------------------------------------
+
+fn cloneParams(allocator: std.mem.Allocator, params: SubscriptionParams) !SubscriptionParams {
+    return switch (params) {
+        .new_heads => SubscriptionParams{ .new_heads = {} },
+        .new_pending_transactions => SubscriptionParams{ .new_pending_transactions = {} },
+        .logs => |lp| blk: {
+            var owned = LogSubscriptionParams{
+                .address = lp.address,
+                .topics = null,
+            };
+            if (lp.topics) |ts| {
+                const copy = try allocator.alloc(?[32]u8, ts.len);
+                @memcpy(copy, ts);
+                owned.topics = copy;
+            }
+            break :blk SubscriptionParams{ .logs = owned };
+        },
+    };
+}
+
+fn freeOwnedParams(allocator: std.mem.Allocator, params: SubscriptionParams) void {
+    switch (params) {
+        .new_heads, .new_pending_transactions => {},
+        .logs => |lp| if (lp.topics) |ts| allocator.free(ts),
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+test "computeBackoffMs - exponential with cap" {
+    const opts = Opts{
+        .initial_backoff_ms = 1_000,
+        .max_backoff_ms = 30_000,
+    };
+    try std.testing.expectEqual(@as(u64, 1_000), computeBackoffMs(opts, 0));
+    try std.testing.expectEqual(@as(u64, 2_000), computeBackoffMs(opts, 1));
+    try std.testing.expectEqual(@as(u64, 4_000), computeBackoffMs(opts, 2));
+    try std.testing.expectEqual(@as(u64, 16_000), computeBackoffMs(opts, 4));
+    // 32_000 would be next; capped to 30_000.
+    try std.testing.expectEqual(@as(u64, 30_000), computeBackoffMs(opts, 5));
+    try std.testing.expectEqual(@as(u64, 30_000), computeBackoffMs(opts, 6));
+    try std.testing.expectEqual(@as(u64, 30_000), computeBackoffMs(opts, 100));
+}
+
+test "computeBackoffMs - zero initial backoff" {
+    const opts = Opts{
+        .initial_backoff_ms = 0,
+        .max_backoff_ms = 30_000,
+    };
+    try std.testing.expectEqual(@as(u64, 0), computeBackoffMs(opts, 0));
+    try std.testing.expectEqual(@as(u64, 0), computeBackoffMs(opts, 5));
+}
+
+test "computeBackoffMs - extreme attempt does not panic" {
+    const opts = Opts{
+        .initial_backoff_ms = 1_000,
+        .max_backoff_ms = 30_000,
+    };
+    // Attempt 1000 must clamp without integer overflow.
+    try std.testing.expectEqual(@as(u64, 30_000), computeBackoffMs(opts, 1000));
+}
+
+test "applyJitter - within bounds" {
+    var prng = std.Random.DefaultPrng.init(0xDEADBEEF);
+    const base: u64 = 1_000;
+    const pct: u8 = 20;
+    var i: usize = 0;
+    while (i < 1000) : (i += 1) {
+        const v = applyJitter(base, pct, prng.random());
+        try std.testing.expect(v >= 800);
+        try std.testing.expect(v <= 1200);
+    }
+}
+
+test "applyJitter - zero pct is identity" {
+    var prng = std.Random.DefaultPrng.init(0xCAFEBABE);
+    try std.testing.expectEqual(@as(u64, 5_000), applyJitter(5_000, 0, prng.random()));
+}
+
+test "applyJitter - zero base is zero" {
+    var prng = std.Random.DefaultPrng.init(0x1234);
+    try std.testing.expectEqual(@as(u64, 0), applyJitter(0, 50, prng.random()));
+}
+
+test "cloneParams + freeOwnedParams - new_heads" {
+    const alloc = std.testing.allocator;
+    const cloned = try cloneParams(alloc, SubscriptionParams{ .new_heads = {} });
+    defer freeOwnedParams(alloc, cloned);
+    try std.testing.expectEqual(SubscriptionType.new_heads, cloned.subType());
+}
+
+test "cloneParams + freeOwnedParams - logs with topics deep copied" {
+    const alloc = std.testing.allocator;
+    var local = [_]?[32]u8{ [_]u8{0xAA} ** 32, null };
+    const params = SubscriptionParams{ .logs = .{
+        .address = [_]u8{0xCC} ** 20,
+        .topics = local[0..],
+    } };
+    const cloned = try cloneParams(alloc, params);
+    defer freeOwnedParams(alloc, cloned);
+    // Mutating the original must not change the clone.
+    local[0] = null;
+    try std.testing.expect(cloned.logs.topics.?[0] != null);
+    try std.testing.expectEqualSlices(u8, &([_]u8{0xAA} ** 32), &cloned.logs.topics.?[0].?);
+}
+
+test "Opts defaults" {
+    const opts = Opts{};
+    try std.testing.expectEqual(@as(u64, 1_000), opts.initial_backoff_ms);
+    try std.testing.expectEqual(@as(u64, 30_000), opts.max_backoff_ms);
+    try std.testing.expectEqual(@as(u32, 0), opts.max_retries);
+    try std.testing.expectEqual(@as(u64, 30_000), opts.ping_interval_ms);
+    try std.testing.expectEqual(@as(u64, 10_000), opts.pong_timeout_ms);
+    try std.testing.expectEqual(@as(u8, 20), opts.jitter_pct);
+}
+
+// ---------------------------------------------------------------------------
+// Tests for dispatch + pending queue.
+//
+// These build a WsClient stub on the stack with no transport, then call the
+// pure logic methods directly. This avoids needing a fake socket layer for
+// the multiplexing tests.
+// ---------------------------------------------------------------------------
+
+fn testStubClient(allocator: std.mem.Allocator) WsClient {
+    return .{
+        .allocator = allocator,
+        .url = &.{},
+        .transport = null,
+        .subs = .empty,
+        .pending = .empty,
+        .next_handle = 1,
+        .next_id = 1,
+        .opts = .{},
+        .state = .connected,
+        .last_activity_ms = 0,
+        .pending_pong = false,
+        .ping_sent_ms = 0,
+        .rng = std.Random.DefaultPrng.init(0),
+    };
+}
+
+fn registerStubSubscription(self: *WsClient, server_id: []const u8) !*Subscription {
+    const sub = try self.allocator.create(Subscription);
+    errdefer self.allocator.destroy(sub);
+    const id_copy = try self.allocator.dupe(u8, server_id);
+    sub.* = .{
+        .handle = self.next_handle,
+        .params = .{ .new_heads = {} },
+        .server_id = id_copy,
+        .client = self,
+    };
+    self.next_handle += 1;
+    try self.subs.append(self.allocator, sub);
+    return sub;
+}
+
+fn freeStubClient(self: *WsClient) void {
+    for (self.subs.items) |s| {
+        self.allocator.free(s.server_id);
+        self.allocator.destroy(s);
+    }
+    self.subs.deinit(self.allocator);
+    for (self.pending.items) |ev| self.allocator.free(ev.payload);
+    self.pending.deinit(self.allocator);
+}
+
+fn fakeNotification(allocator: std.mem.Allocator, sub_id: []const u8) ![]u8 {
+    return std.fmt.allocPrint(
+        allocator,
+        "{{\"jsonrpc\":\"2.0\",\"method\":\"eth_subscription\",\"params\":{{\"subscription\":\"{s}\",\"result\":{{}}}}}}",
+        .{sub_id},
+    );
+}
+
+test "dispatch - matches subscription by server_id" {
+    const alloc = std.testing.allocator;
+    var client = testStubClient(alloc);
+    defer freeStubClient(&client);
+
+    const sub_a = try registerStubSubscription(&client, "0xaaa");
+    _ = try registerStubSubscription(&client, "0xbbb");
+
+    const frame = try fakeNotification(alloc, "0xaaa");
+    const event_opt = try client.dispatch(frame);
+    const event = event_opt orelse return error.TestExpectedSome;
+    defer alloc.free(event.payload);
+    try std.testing.expect(event.sub == sub_a);
+}
+
+test "dispatch - unknown sub_id frees frame and returns null" {
+    const alloc = std.testing.allocator;
+    var client = testStubClient(alloc);
+    defer freeStubClient(&client);
+
+    _ = try registerStubSubscription(&client, "0xaaa");
+
+    const frame = try fakeNotification(alloc, "0xstale");
+    const event_opt = try client.dispatch(frame);
+    try std.testing.expect(event_opt == null);
+    // dispatch frees the frame on no-match; if it leaked, the testing
+    // allocator would fail this test.
+}
+
+test "queueNotification - preserves arrival order" {
+    const alloc = std.testing.allocator;
+    var client = testStubClient(alloc);
+    defer freeStubClient(&client);
+
+    const sub_a = try registerStubSubscription(&client, "0xaaa");
+    const sub_b = try registerStubSubscription(&client, "0xbbb");
+
+    const f1 = try fakeNotification(alloc, "0xaaa");
+    const f2 = try fakeNotification(alloc, "0xbbb");
+    const f3 = try fakeNotification(alloc, "0xaaa");
+
+    try std.testing.expect(try client.queueNotification(f1));
+    try std.testing.expect(try client.queueNotification(f2));
+    try std.testing.expect(try client.queueNotification(f3));
+
+    try std.testing.expectEqual(@as(usize, 3), client.pending.items.len);
+    try std.testing.expect(client.pending.items[0].sub == sub_a);
+    try std.testing.expect(client.pending.items[1].sub == sub_b);
+    try std.testing.expect(client.pending.items[2].sub == sub_a);
+}
+
+test "queueNotification - rejects unknown sub_id" {
+    const alloc = std.testing.allocator;
+    var client = testStubClient(alloc);
+    defer freeStubClient(&client);
+
+    _ = try registerStubSubscription(&client, "0xaaa");
+
+    const f = try fakeNotification(alloc, "0xunknown");
+    defer alloc.free(f);
+    try std.testing.expect(!try client.queueNotification(f));
+    try std.testing.expectEqual(@as(usize, 0), client.pending.items.len);
+}
+
+test "subscription registry - server_id remap preserves handle" {
+    const alloc = std.testing.allocator;
+    var client = testStubClient(alloc);
+    defer freeStubClient(&client);
+
+    const sub = try registerStubSubscription(&client, "0xold");
+    const handle_before = sub.handle;
+
+    // Simulate what resubscribeAll does: free the old id, install a new one.
+    alloc.free(sub.server_id);
+    sub.server_id = try alloc.dupe(u8, "0xnew");
+
+    // Handle and pointer are stable; only the server_id changed.
+    try std.testing.expectEqual(handle_before, sub.handle);
+    try std.testing.expectEqualStrings("0xnew", sub.server_id);
+
+    // Notifications addressed to the new id now dispatch to the same handle.
+    const f = try fakeNotification(alloc, "0xnew");
+    const event_opt = try client.dispatch(f);
+    const event = event_opt orelse return error.TestExpectedSome;
+    defer alloc.free(event.payload);
+    try std.testing.expect(event.sub == sub);
+}

--- a/src/ws_transport.zig
+++ b/src/ws_transport.zig
@@ -306,6 +306,11 @@ pub const WsTransport = struct {
     read_pos: usize = 0,
     read_end: usize = 0,
 
+    /// Total number of frames (data + control) received since this transport
+    /// was opened. Higher-level wrappers can sample this to detect liveness
+    /// of pong responses without piercing the abstraction.
+    frames_received: u64 = 0,
+
     // Track whether we use TLS
     is_tls: bool = false,
 
@@ -340,6 +345,7 @@ pub const WsTransport = struct {
         TlsInitFailed,
         WriteError,
         ReadError,
+        Timeout,
     };
 
     /// Connect to a WebSocket endpoint.
@@ -459,10 +465,52 @@ pub const WsTransport = struct {
         return self.sendFrame(payload, .text);
     }
 
+    /// Send a WebSocket ping frame with the given payload (RFC 6455 limits
+    /// payload to 125 bytes; the caller is responsible for honoring that).
+    /// The peer is expected to reply with a pong carrying the same payload.
+    pub fn sendPing(self: *WsTransport, payload: []const u8) !void {
+        return self.sendFrame(payload, .ping);
+    }
+
     /// Read the next WebSocket message (text or binary).
     /// Caller owns the returned memory.
     pub fn readMessage(self: *WsTransport) ![]u8 {
         return self.readFrame();
+    }
+
+    /// Read the next WebSocket message with a deadline.
+    ///
+    /// `deadline_ms` is an absolute timestamp from `std.time.milliTimestamp()`.
+    /// Returns the payload (caller owns memory) on success, or null if the
+    /// deadline expires before a complete data frame is available.
+    ///
+    /// Control frames (ping/pong) are handled transparently as in `readFrame`.
+    /// Note: with TLS, a partially-arrived TLS record may cause the underlying
+    /// read to block briefly past the deadline while the record is assembled.
+    pub fn readMessageDeadline(self: *WsTransport, deadline_ms: i64) !?[]u8 {
+        return self.readFrameDeadline(deadline_ms);
+    }
+
+    /// Wait for the underlying socket to become readable, or for `timeout_ms`
+    /// to elapse. Returns true if data is ready, false on timeout.
+    /// Pass a negative timeout to block indefinitely.
+    pub fn pollReadable(self: *WsTransport, timeout_ms: i32) !bool {
+        // If the read buffer already has unconsumed bytes, we are immediately
+        // readable from the caller's perspective.
+        if (self.read_end > self.read_pos) return true;
+        var fds = [_]std.posix.pollfd{.{
+            .fd = self.stream.handle,
+            .events = std.posix.POLL.IN,
+            .revents = 0,
+        }};
+        const n = std.posix.poll(&fds, timeout_ms) catch return error.ReadError;
+        if (n == 0) return false;
+        // POLLERR / POLLHUP / POLLNVAL all indicate the socket is no longer
+        // usable; surface that as ReadError so the caller triggers reconnect.
+        if (fds[0].revents & (std.posix.POLL.ERR | std.posix.POLL.HUP | std.posix.POLL.NVAL) != 0) {
+            return error.ReadError;
+        }
+        return (fds[0].revents & std.posix.POLL.IN) != 0;
     }
 
     // -- Internal methods --
@@ -484,16 +532,28 @@ pub const WsTransport = struct {
     /// Caller owns the returned memory.
     /// Handles ping frames internally by responding with pong.
     fn readFrame(self: *WsTransport) ![]u8 {
+        return (try self.readFrameImpl(null)) orelse unreachable;
+    }
+
+    /// Read a complete WebSocket frame, returning null on deadline.
+    /// `deadline_ms` is absolute (`std.time.milliTimestamp()` units).
+    fn readFrameDeadline(self: *WsTransport, deadline_ms: i64) !?[]u8 {
+        return self.readFrameImpl(deadline_ms);
+    }
+
+    /// Shared implementation for `readFrame` (no deadline) and
+    /// `readFrameDeadline` (returns null on timeout).
+    fn readFrameImpl(self: *WsTransport, deadline_ms: ?i64) !?[]u8 {
         while (true) {
             // Ensure we have at least 2 bytes for the header
-            try self.ensureReadBuf(2);
+            if (!try self.ensureReadBufDeadline(2, deadline_ms)) return null;
 
             const available = self.read_buf[self.read_pos..self.read_end];
             const header_opt = decodeFrameHeader(available);
 
             if (header_opt == null) {
                 // Need more data for header
-                try self.fillReadBuf();
+                if (!try self.fillReadBufDeadline(deadline_ms)) return null;
                 continue;
             }
 
@@ -505,7 +565,7 @@ pub const WsTransport = struct {
             }
 
             // Ensure we have the entire frame in the buffer
-            try self.ensureReadBuf(total_frame_size);
+            if (!try self.ensureReadBufDeadline(total_frame_size, deadline_ms)) return null;
 
             const payload_start = self.read_pos + header.header_size;
             const payload_end = payload_start + @as(usize, @intCast(header.payload_len));
@@ -525,6 +585,7 @@ pub const WsTransport = struct {
 
             // Advance read position past this frame
             self.read_pos = payload_end;
+            self.frames_received +%= 1;
 
             // Handle control frames transparently
             switch (header.opcode) {
@@ -593,13 +654,27 @@ pub const WsTransport = struct {
     /// Ensure the read buffer has at least `min_bytes` available from
     /// the current read_pos.
     fn ensureReadBuf(self: *WsTransport, min_bytes: usize) !void {
-        while (self.read_end - self.read_pos < min_bytes) {
-            try self.fillReadBuf();
-        }
+        _ = try self.ensureReadBufDeadline(min_bytes, null);
     }
 
     /// Read more data from the network into the read buffer.
     fn fillReadBuf(self: *WsTransport) !void {
+        _ = try self.fillReadBufDeadline(null);
+    }
+
+    /// Ensure the read buffer has at least `min_bytes` available, respecting
+    /// `deadline_ms` (absolute milliseconds). Returns true on success, false
+    /// if the deadline expired before enough bytes arrived.
+    fn ensureReadBufDeadline(self: *WsTransport, min_bytes: usize, deadline_ms: ?i64) !bool {
+        while (self.read_end - self.read_pos < min_bytes) {
+            if (!try self.fillReadBufDeadline(deadline_ms)) return false;
+        }
+        return true;
+    }
+
+    /// Read more data from the network into the read buffer, optionally
+    /// bounded by `deadline_ms`. Returns true on read, false on timeout.
+    fn fillReadBufDeadline(self: *WsTransport, deadline_ms: ?i64) !bool {
         // Compact: shift remaining data to the front
         if (self.read_pos > 0) {
             const remaining = self.read_end - self.read_pos;
@@ -610,9 +685,22 @@ pub const WsTransport = struct {
             self.read_pos = 0;
         }
 
+        if (deadline_ms) |dl| {
+            const now = std.time.milliTimestamp();
+            if (now >= dl) return false;
+            const wait_i64 = dl - now;
+            const wait_ms: i32 = if (wait_i64 > std.math.maxInt(i32))
+                std.math.maxInt(i32)
+            else
+                @intCast(wait_i64);
+            const ready = try self.pollReadable(wait_ms);
+            if (!ready) return false;
+        }
+
         const n = self.readSome(self.read_buf[self.read_end..]) catch return error.ReadError;
         if (n == 0) return error.ConnectionClosed;
         self.read_end += n;
+        return true;
     }
 
     /// Write all bytes to the underlying transport (plain TCP or TLS).

--- a/tests/integration_tests.zig
+++ b/tests/integration_tests.zig
@@ -80,7 +80,7 @@ test "getBalance of funded account" {
 
     // Anvil accounts start with 10000 ETH. Even after some tests run the
     // balance should be well above 1 ETH (= 10^18 wei).
-    const one_ether = eth.units.parseEther(1.0);
+    const one_ether = eth.units.parseEther(1.0) orelse return error.ParseEtherFailed;
     try std.testing.expect(balance >= one_ether);
 }
 
@@ -216,7 +216,7 @@ test "send ETH transfer and verify receipt" {
     var wallet = eth.wallet.Wallet.init(allocator, private_key, &provider);
 
     const recipient = try eth.primitives.addressFromHex(ACCOUNT_1_ADDR_HEX);
-    const send_value = eth.units.parseEther(0.01);
+    const send_value = eth.units.parseEther(0.01) orelse return error.ParseEtherFailed;
 
     // Record initial balance of recipient.
     const balance_before = try provider.getBalance(recipient);
@@ -283,7 +283,7 @@ test "sendTransactionAndWait returns receipt directly" {
     var wallet = eth.wallet.Wallet.init(allocator, private_key, &provider);
 
     const recipient = try eth.primitives.addressFromHex(ACCOUNT_1_ADDR_HEX);
-    const send_value = eth.units.parseEther(0.001);
+    const send_value = eth.units.parseEther(0.001) orelse return error.ParseEtherFailed;
 
     const receipt = try wallet.sendTransactionAndWait(.{
         .to = recipient,
@@ -328,4 +328,84 @@ test "provider next_id increments across calls" {
     const id_after_first = provider.next_id;
     _ = try provider.getBlockNumber();
     try std.testing.expect(provider.next_id > id_after_first);
+}
+
+// ============================================================================
+// WsClient: resilient WebSocket subscriptions (issue #35)
+// ============================================================================
+
+const ANVIL_WS_URL = "ws://127.0.0.1:8545";
+
+/// Trigger a block on Anvil so newHeads subscriptions emit a notification.
+fn anvilMineOne(allocator: std.mem.Allocator) !void {
+    var transport = eth.http_transport.HttpTransport.init(allocator, ANVIL_URL);
+    defer transport.deinit();
+    const response = try transport.request("evm_mine", "[]", 1);
+    allocator.free(response);
+}
+
+test "WsClient subscribe newHeads receives a fresh block" {
+    if (!isAnvilAvailable()) return;
+    const allocator = std.testing.allocator;
+
+    // Disable keepalive in tests so the test's run time is bounded by
+    // mining + dispatch, not by the default 30s ping interval.
+    const opts = eth.ws_client.Opts{ .ping_interval_ms = 0 };
+    const client = try eth.ws_client.WsClient.connect(allocator, ANVIL_WS_URL, opts);
+    defer client.deinit();
+
+    const sub = try client.subscribe(.{ .new_heads = {} });
+
+    try anvilMineOne(allocator);
+
+    const event = try client.next();
+    defer allocator.free(event.payload);
+    try std.testing.expect(event.sub == sub);
+    // Sanity-check the payload is a newHeads notification for our sub.
+    try std.testing.expect(std.mem.indexOf(u8, event.payload, "eth_subscription") != null);
+    try std.testing.expect(std.mem.indexOf(u8, event.payload, sub.server_id) != null);
+}
+
+test "WsClient multiplexes two subscriptions on one connection" {
+    if (!isAnvilAvailable()) return;
+    const allocator = std.testing.allocator;
+
+    const opts = eth.ws_client.Opts{ .ping_interval_ms = 0 };
+    const client = try eth.ws_client.WsClient.connect(allocator, ANVIL_WS_URL, opts);
+    defer client.deinit();
+
+    const sub_a = try client.subscribe(.{ .new_heads = {} });
+    const sub_b = try client.subscribe(.{ .new_heads = {} });
+    // Both subs are newHeads, so each freshly-mined block emits one event per
+    // sub. Anvil assigns each sub a distinct server_id, so dispatch must
+    // route correctly.
+    try std.testing.expect(!std.mem.eql(u8, sub_a.server_id, sub_b.server_id));
+
+    try anvilMineOne(allocator);
+
+    var saw_a = false;
+    var saw_b = false;
+    var i: usize = 0;
+    while ((!saw_a or !saw_b) and i < 4) : (i += 1) {
+        const ev = try client.next();
+        defer allocator.free(ev.payload);
+        if (ev.sub == sub_a) saw_a = true;
+        if (ev.sub == sub_b) saw_b = true;
+    }
+    try std.testing.expect(saw_a);
+    try std.testing.expect(saw_b);
+}
+
+test "WsClient unsubscribe frees handle and removes from registry" {
+    if (!isAnvilAvailable()) return;
+    const allocator = std.testing.allocator;
+
+    const opts = eth.ws_client.Opts{ .ping_interval_ms = 0 };
+    const client = try eth.ws_client.WsClient.connect(allocator, ANVIL_WS_URL, opts);
+    defer client.deinit();
+
+    const sub = try client.subscribe(.{ .new_heads = {} });
+    try client.unsubscribe(sub);
+    // The registry should be empty; pointer `sub` is freed and must not be
+    // dereferenced after this point.
 }


### PR DESCRIPTION
## Summary

Adds `ws_client.WsClient`: a resilient WebSocket client that wraps the existing `ws_transport.WsTransport` with the three features production bots need (issue #35):

- **Transparent reconnect with exponential backoff + jitter.** When the socket drops, `next()` and `request()` rebuild the transport and re-issue every active `eth_subscribe` before returning. Subscription handles stay valid across reconnects -- the underlying server-side sub-id is swapped automatically.
- **Multiplexed subscriptions.** Multiple `Subscription` handles share one connection; notifications are dispatched to the right handle. Fixes a latent bug where `subscription.Subscription.next()` silently dropped notifications destined for other subs on the same transport.
- **Application-layer keepalive.** A ping is sent if no frames arrive for `ping_interval_ms`. If no pong arrives within `pong_timeout_ms`, the connection is treated as dead and reconnect is triggered.

Single-threaded by design -- all I/O happens synchronously inside `next()` / `request()` / `subscribe()` / `unsubscribe()`. No background threads, locks, or callbacks. Matches the existing I/O model in eth.zig and avoids the Zig 0.16 mutex-copy pitfalls flagged in CLAUDE.md.

The lower-level `WsTransport` and `connectWithReconnect` API stays unchanged.

## Notable changes

- **NEW `src/ws_client.zig`** -- `WsClient`, handle-style `Subscription`, `Opts`/`Event`/`Error`, reconnect+resubscribe state machine, pending-notification queue.
- `src/ws_transport.zig` -- `readFrameDeadline` + `pollReadable` (poll-based deadline reads), `sendPing`, and a `frames_received` counter so `WsClient` can detect liveness via control frames.
- `src/subscription.zig` -- promoted `extractResultString`, `isSubscriptionNotification`, `getNotificationResult` to `pub`. Lifted `nextBlock`/`nextLog`/`nextTxHash` bodies into free `parseBlockFromNotification` / `parseLogFromNotification` / `parseTxHashFromNotification` so `WsClient` reuses them without needing a `Subscription` instance. Added `getSubscriptionId` and `extractResponseId` helpers.
- `README.md` -- new "Resilient WebSocket subscriptions" Quick Start example.

### Drive-by

`tests/integration_tests.zig` had 3 pre-existing compile errors on `origin/main` (callers of `parseEther` -- which returns `?u256` -- forgot to unwrap). The file was uncompilable. Fixed inline so the new integration tests can run.

## Test plan

- [x] `make ci` passes (build + `zig fmt --check src/ tests/` + 1300+ unit tests)
- [x] `zig build integration-test` against a local Anvil: 18/18 tests pass, including:
  - `WsClient subscribe newHeads receives a fresh block`
  - `WsClient multiplexes two subscriptions on one connection`
  - `WsClient unsubscribe frees handle and removes from registry`
- [x] `coderabbit review --prompt-only --type committed --base origin/main`: no findings
- [x] No `std.debug.print` in library code, no emojis

## Out of scope

- Pending-tx full-tx subscription (issue #14)
- Connection pool / multi-endpoint failover
- Async/await API
- Bounded pending-notification queue with drop policy (v1 is unbounded)
- TCP-level `SO_KEEPALIVE` (application ping is sufficient and portable)

Closes #35.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resilient WebSocket client with automatic reconnect, backoff + jitter, resubscribe on reconnect, multiplexed subscriptions, queued notifications, ping/pong keepalive, and public client APIs (connect/subscribe/unsubscribe/next/request).
  * New public helpers for parsing and handling subscription notifications.

* **Documentation**
  * README updated with examples and guidance for the new WebSocket client and transport.

* **Tests**
  * Added WebSocket integration tests and unit tests covering helpers, backoff/jitter, notification dispatch, and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->