### PR TITLE
Backfill CHANGELOG through v0.4.0 and align all version references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,84 @@ All notable changes to eth.zig will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-06-09
+
+### Added
+- `WsClient`: resilient WebSocket subscription client with transparent reconnect, exponential backoff with jitter, ping/pong keepalive, and multiplexed subscriptions over a single connection (#51)
+- Full pending-transaction subscriptions: `newPendingTransactions` with `full: true` streams complete `RpcTransaction` values instead of hashes; tolerates nodes that fall back to hash-only notifications (#53)
+- `RpcTransaction` type and `parseSingleTransaction` for `eth_getTransactionByHash`-shaped payloads (#53)
+- `eth_call` state overrides: set balance, nonce, code, and storage (full state or diff) per call via `callWithOverrides` (#54)
+- Server-Sent Events (SSE) transport with last-event-id reconnect support (#48)
+- Typed subscription params and lifecycle management (#43)
+- `RetryingProvider`: configurable retry middleware with exponential backoff and connection-error filtering (#41)
+- Batch `eth_call` fan-out via `BatchCaller` (#42)
+- Pure Zig DEX math for UniswapV2 (`getAmountOut`/`getAmountIn`) plus V3 and router scaffolding (#42)
+- Makefile with `ci`, `test`, `fmt`, `integration-test`, and bench targets (#45)
+
+### Changed
+- Replaced all uses of the `**` array-repetition operator with `@splat`, restoring compatibility with Zig master (0.17.0-dev) while keeping 0.15.2 as the minimum supported version (#56)
+- Malformed transaction fields from RPC (`transactionIndex`, `type`, missing `v`/`yParity`) now fail fast with `error.InvalidResponse` instead of being silently coerced (#53)
+
+### Fixed
+- 21 security, correctness, and code-quality issues across the library (#44)
+- WebSocket resubscribe-after-reconnect edge case (#53)
+
+### Security
+- Docs site upgraded to Next 16 / Fumadocs 16, clearing all `pnpm audit` findings (#57)
+
+## [0.3.0] - 2026-03-09
+
+### Added
+- Flashbots MEV support: `eth_sendBundle`, `eth_callBundle`, `eth_cancelBundle`, and MEV-Share `mev_sendBundle` with privacy hints and refund configs (#32)
+
+### Changed
+- Vendored libsecp256k1 (Bitcoin Core) with native u128 `mulDiv`; 23/26 benchmark wins vs alloy.rs (#31)
+- u256 limb-native compound arithmetic: UniswapV2 `getAmountOut` 87ns -> 20ns, beating the Rust implementation (#30, #29)
+- Replaced stdlib Keccak with XKCP (CPU-adaptive AVX512/AVX2/plain64) for ~1.4x hashing speedup (#28)
+- Benchmarks migrated to zbench (#24)
+
+### Removed
+- `abi_comptime` module: selector and event-topic hashing unified under a single comptime-friendly API (**breaking**) (#25)
+
+## [0.2.3] - 2026-02-28
+
+### Added
+- Documentation site at [ethzig.org](https://ethzig.org) (#8)
+
+### Changed
+- GLV endomorphism for secp256k1 and lane-complementing Keccak; fastest crypto benchmarks vs Voltaire across the board (#22)
+
+### Fixed
+- Deprecated allocator initialization patterns; fixed an LLVM crash in tests (#10)
+
+## [0.2.2] - 2026-02-26
+
+### Added
+- ~90 cross-validation tests asserting byte-for-byte parity with alloy.rs outputs (#5)
+- `SECURITY.md` and pull-request template
+
+### Changed
+- Performance optimizations: 19/26 benchmark wins vs alloy.rs (#4)
+
+### Fixed
+- Test nitpicks: pinned expected digests, reused helpers, f64 precision (#7)
+
+## [0.2.1] - 2026-02-26
+
+### Changed
+- Performance optimizations across u256, ABI, and crypto paths: 18/24 benchmark wins vs alloy.rs (#3)
+
+## [0.2.0] - 2026-02-26
+
+### Added
+- ERC-20 and ERC-721 typed contract wrappers (#1)
+- JSON ABI parser for Solidity compiler output (#1)
+- Runnable examples under `examples/` (#1)
+- Anvil-backed integration test suite (#2)
+
+### Fixed
+- Zig 0.15.2 compatibility (#1)
+
 ## [0.1.0] - 2026-02-26
 
 Initial release of eth.zig -- a feature-complete, pure Zig Ethereum client library.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Built something with eth.zig? Open a PR to add it here.
 **One-liner:**
 
 ```bash
-zig fetch --save git+https://github.com/StrobeLabs/eth.zig.git#v0.2.2
+zig fetch --save git+https://github.com/StrobeLabs/eth.zig.git#v0.4.0
 ```
 
 **Or add manually** to your `build.zig.zon`:
@@ -204,7 +204,7 @@ zig fetch --save git+https://github.com/StrobeLabs/eth.zig.git#v0.2.2
 ```zig
 .dependencies = .{
     .eth = .{
-        .url = "git+https://github.com/StrobeLabs/eth.zig.git#v0.2.2",
+        .url = "git+https://github.com/StrobeLabs/eth.zig.git#v0.4.0",
         .hash = "...", // run `zig build` and it will tell you the expected hash
     },
 },

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.1.x   | Yes       |
+| 0.4.x   | Yes       |
+| < 0.4   | No        |
 
 ## Reporting a Vulnerability
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .eth_zig,
-    .version = "0.3.0",
+    .version = "0.4.0",
     .fingerprint = 0xd0f21900fa26f179,
     .minimum_zig_version = "0.15.2",
     .dependencies = .{},

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -13,7 +13,7 @@ description: How to add eth.zig to your Zig project.
 **One-liner:**
 
 ```bash
-zig fetch --save git+https://github.com/StrobeLabs/eth.zig.git#v0.2.2
+zig fetch --save git+https://github.com/StrobeLabs/eth.zig.git#v0.4.0
 ```
 
 **Or add manually** to your `build.zig.zon`:
@@ -21,7 +21,7 @@ zig fetch --save git+https://github.com/StrobeLabs/eth.zig.git#v0.2.2
 ```zig
 .dependencies = .{
     .eth = .{
-        .url = "git+https://github.com/StrobeLabs/eth.zig.git#v0.2.2",
+        .url = "git+https://github.com/StrobeLabs/eth.zig.git#v0.4.0",
         .hash = "...", // run `zig build` and it will tell you the expected hash
     },
 },


### PR DESCRIPTION
## What
Brings the CHANGELOG and every version reference in the repo up to date, preparing the v0.4.0 release.

## Why
`CHANGELOG.md` only documented v0.1.0 even though v0.2.0–v0.3.0 are tagged and released, `build.zig.zon` said 0.3.0, the README and docs told users to install `#v0.2.2`, and SECURITY.md claimed only 0.1.x is supported. Inconsistent versioning is one of the first things prospective adopters notice.

## How
- Backfilled Keep-a-Changelog entries for 0.2.0, 0.2.1, 0.2.2, 0.2.3, and 0.3.0 from the tagged commit history
- Added the 0.4.0 entry: WsClient auto-reconnect (#51), eth_call state overrides (#54), full pending-tx subscriptions (#53), SSE transport (#48), typed subscriptions (#43), retry middleware (#41), batch eth_call + DEX math (#42), security fixes (#44), Zig-master @splat migration (#56)
- `build.zig.zon` 0.3.0 → 0.4.0; README/docs install URLs → `#v0.4.0`; SECURITY.md supported versions → 0.4.x

After merge I'll tag `v0.4.0` and publish the GitHub release with these notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebSocket and SSE transport options added
  * Subscription enhancements with typed parameters and lifecycle management
  * RpcTransaction parsing and eth_call overrides support
  * Retry middleware and BatchCaller utility
  * Zig DEX math scaffolding and Makefile automation

* **Documentation**
  * Installation guides and security policy updated for v0.4.0 compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->