### PR TITLE
Release v0.5.0: version bump and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to eth.zig will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-06-10
 
 ### Changed
 - Minimum supported Zig version is now 0.16.0. Transports (HTTP, WebSocket, SSE), retry backoff, and receipt polling were migrated to the new `std.Io` interface; the library constructs a default blocking `std.Io` internally, so public signatures are unchanged. This is a breaking change for Zig 0.15 users

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Built something with eth.zig? Open a PR to add it here.
 **One-liner:**
 
 ```bash
-zig fetch --save git+https://github.com/StrobeLabs/eth.zig.git#v0.4.0
+zig fetch --save git+https://github.com/StrobeLabs/eth.zig.git#v0.5.0
 ```
 
 **Or add manually** to your `build.zig.zon`:
@@ -221,7 +221,7 @@ zig fetch --save git+https://github.com/StrobeLabs/eth.zig.git#v0.4.0
 ```zig
 .dependencies = .{
     .eth = .{
-        .url = "git+https://github.com/StrobeLabs/eth.zig.git#v0.4.0",
+        .url = "git+https://github.com/StrobeLabs/eth.zig.git#v0.5.0",
         .hash = "...", // run `zig build` and it will tell you the expected hash
     },
 },

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.4.x   | Yes       |
-| < 0.4   | No        |
+| 0.5.x   | Yes       |
+| < 0.5   | No        |
 
 ## Reporting a Vulnerability
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .eth_zig,
-    .version = "0.4.0",
+    .version = "0.5.0",
     .fingerprint = 0xd0f21900fa26f179,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{},

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -13,7 +13,7 @@ description: How to add eth.zig to your Zig project.
 **One-liner:**
 
 ```bash
-zig fetch --save git+https://github.com/StrobeLabs/eth.zig.git#v0.4.0
+zig fetch --save git+https://github.com/StrobeLabs/eth.zig.git#v0.5.0
 ```
 
 **Or add manually** to your `build.zig.zon`:
@@ -21,7 +21,7 @@ zig fetch --save git+https://github.com/StrobeLabs/eth.zig.git#v0.4.0
 ```zig
 .dependencies = .{
     .eth = .{
-        .url = "git+https://github.com/StrobeLabs/eth.zig.git#v0.4.0",
+        .url = "git+https://github.com/StrobeLabs/eth.zig.git#v0.5.0",
         .hash = "...", // run `zig build` and it will tell you the expected hash
     },
 },


### PR DESCRIPTION
Converts the Unreleased changelog section to **0.5.0** (log_watcher #59, Zig 0.16 migration #60) and aligns all version references: build.zig.zon, README/docs install URLs, SECURITY.md supported versions.

After merge: tag v0.5.0, publish the GitHub release, and reply to #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `eth.runtime` module helpers
  * Added `log_watcher` functionality
  * Added `provider.parseBlockHeaderObject`

* **Bug Fixes**
  * Fixed subscription log parsing for Zig 0.15.2 compatibility

* **Chores**
  * Released version 0.5.0
  * Increased minimum Zig version requirement to 0.16.0
  * Updated installation documentation and guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->