### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to eth.zig will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2026-06-11
 
 ### Added
 - EIP-7702 SetCode transactions (type 0x04), shipped in Pectra and live on mainnet (#66). New `transaction.Authorization` tuple `{chain_id, address, nonce, y_parity, r, s}` and `transaction.Eip7702Transaction` (note: `to` is non-nullable -- type-0x04 cannot create contracts), wired into the `Transaction` union and the `serializeForSigning`/`hashForSigning`/`serializeSigned` dispatch. The signing payload is `0x04 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value, data, access_list, authorization_list])` (signed appends `y_parity, r, s`), each authorization encoded as `[chain_id, address, nonce, y_parity, r, s]`. `signer.signAuthorization(allocator, chain_id, address, nonce)` signs the authorization hash `keccak256(0x05 || rlp([chain_id, address, nonce]))` (MAGIC = 0x05) and fills `y_parity/r/s`; `signer.hashAuthorization` exposes that hash. `rpc_transaction.RpcTransaction` gains an optional `authorization_list`, parsed best-effort from an RPC `authorizationList`. Verified via sign-then-recover round trip (recovered signer equals the authority) plus fixed RLP-shape assertions; no official EIP-7702 signing test vector was found in the EIP or this repo, so correctness rests on the round trip plus shape checks

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Built something with eth.zig? Open a PR to add it here.
 **One-liner:**
 
 ```bash
-zig fetch --save git+https://github.com/StrobeLabs/eth.zig.git#v0.6.0
+zig fetch --save git+https://github.com/StrobeLabs/eth.zig.git#v0.7.0
 ```
 
 **Or add manually** to your `build.zig.zon`:
@@ -222,7 +222,7 @@ zig fetch --save git+https://github.com/StrobeLabs/eth.zig.git#v0.6.0
 ```zig
 .dependencies = .{
     .eth = .{
-        .url = "git+https://github.com/StrobeLabs/eth.zig.git#v0.6.0",
+        .url = "git+https://github.com/StrobeLabs/eth.zig.git#v0.7.0",
         .hash = "...", // run `zig build` and it will tell you the expected hash
     },
 },

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.6.x   | Yes       |
-| < 0.6   | No        |
+| 0.7.x   | Yes       |
+| < 0.7   | No        |
 
 ## Reporting a Vulnerability
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .eth_zig,
-    .version = "0.6.0",
+    .version = "0.7.0",
     .fingerprint = 0xd0f21900fa26f179,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{},

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -13,7 +13,7 @@ description: How to add eth.zig to your Zig project.
 **One-liner:**
 
 ```bash
-zig fetch --save git+https://github.com/StrobeLabs/eth.zig.git#v0.6.0
+zig fetch --save git+https://github.com/StrobeLabs/eth.zig.git#v0.7.0
 ```
 
 **Or add manually** to your `build.zig.zon`:
@@ -21,7 +21,7 @@ zig fetch --save git+https://github.com/StrobeLabs/eth.zig.git#v0.6.0
 ```zig
 .dependencies = .{
     .eth = .{
-        .url = "git+https://github.com/StrobeLabs/eth.zig.git#v0.6.0",
+        .url = "git+https://github.com/StrobeLabs/eth.zig.git#v0.7.0",
         .hash = "...", // run `zig build` and it will tell you the expected hash
     },
 },


### PR DESCRIPTION
Cuts **v0.7.0**, aligning all version references.

## Highlights since v0.6.0
- **Encrypted JSON keystore** (#65): Web3 Secret Storage v3 decrypt/encrypt (scrypt + pbkdf2, AES-128-CTR, constant-time Keccak MAC), interop-verified against the canonical geth fixtures -- removes a hard onboarding blocker for users with existing keys.
- **FallbackProvider** (#70): multi-RPC failover with per-endpoint health tracking and recovery probing; fails over on transport errors but not on real RPC answers.
- **EIP-7702 SetCode transactions** (#66): type 0x04 with signed authorizations (`signAuthorization`, the 0x05-magic signing hash), serialization, and RPC parsing -- Pectra parity with alloy/viem.

Suite: 811/811, zero skips. After merge: tag v0.7.0 and publish the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 0.7.0
  * Bumped package version to 0.7.0
  * Updated changelog to mark the 0.7.0 release
  * Updated security policy to reflect support for 0.7.x

* **Documentation**
  * Updated installation instructions and README to reference the 0.7.0 dependency
  * Updated website docs to use eth v0.7.0 in install examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->