### PR TITLE
CI: standardize on Zig 0.16.0 (drop master job)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        zig-version: ["0.16.0", "master"]
+        zig-version: ["0.16.0"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
eth.zig targets **Zig 0.16.0 exclusively** (`minimum_zig_version = "0.16.0"`). The CI matrix also tested the `master` (0.17-dev) nightly, which is an unreleased moving target — it added churn (e.g. the `Type.Struct.fields` rename) without a forward-compat goal we care about.

This drops `master` from the test matrix. CI now tests only 0.16.0 on ubuntu + macos. Strict version standardization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)