### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test / Zig ${{ matrix.zig-version }} / ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/StrobeLabs/eth.zig/security/code-scanning/1](https://github.com/StrobeLabs/eth.zig/security/code-scanning/1)

Add an explicit top-level `permissions` block to `.github/workflows/ci.yml` so all jobs inherit least-privilege token scope. For this workflow, `contents: read` is sufficient (needed by `actions/checkout` and read-only build/test tasks).  
Best single fix: insert the block right after the `on:` section (before `jobs:`), preserving existing behavior while enforcing minimal token permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow permissions to use read-only access for repository contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->