### PR TITLE
fix: KMS stale-connection retry, verified broadcast, real signer errors

### DIFF
--- a/src/kms.zig
+++ b/src/kms.zig
@@ -119,9 +119,6 @@ pub const Client = struct {
         });
         defer self.allocator.free(authorization);
 
-        var response_body: std.Io.Writer.Allocating = .init(self.allocator);
-        errdefer response_body.deinit();
-
         var header_buf: [5]std.http.Header = undefined;
         var n: usize = 0;
         header_buf[n] = .{ .name = "Content-Type", .value = "application/x-amz-json-1.1" };
@@ -137,24 +134,37 @@ pub const Client = struct {
             n += 1;
         }
 
-        const result = self.http.fetch(.{
-            .location = .{ .url = url },
-            .method = .POST,
-            .payload = body,
-            .extra_headers = header_buf[0..n],
-            .response_writer = &response_body.writer,
-        }) catch {
+        // Signing calls can be minutes apart, and KMS closes idle keep-alive
+        // connections well before that, so the pooled connection is routinely
+        // dead by the next call and the first write fails. The failed fetch
+        // discards that connection; one retry dials fresh.
+        var attempt: u2 = 0;
+        while (true) : (attempt += 1) {
+            var response_body: std.Io.Writer.Allocating = .init(self.allocator);
+
+            const result = self.http.fetch(.{
+                .location = .{ .url = url },
+                .method = .POST,
+                .payload = body,
+                .extra_headers = header_buf[0..n],
+                .response_writer = &response_body.writer,
+            }) catch {
+                response_body.deinit();
+                if (attempt == 0) continue;
+                return KmsError.RequestFailed;
+            };
+
+            if (result.status == .ok) {
+                errdefer response_body.deinit();
+                return response_body.toOwnedSlice();
+            }
+
             response_body.deinit();
-            return KmsError.RequestFailed;
-        };
-
-        if (result.status == .ok) return response_body.toOwnedSlice();
-
-        response_body.deinit();
-        return switch (result.status) {
-            .forbidden, .unauthorized => KmsError.Unauthorized,
-            else => KmsError.RequestFailed,
-        };
+            return switch (result.status) {
+                .forbidden, .unauthorized => KmsError.Unauthorized,
+                else => KmsError.RequestFailed,
+            };
+        }
     }
 };
 

--- a/src/wallet.zig
+++ b/src/wallet.zig
@@ -22,7 +22,6 @@ pub const SendTransactionOpts = struct {
 
 pub const WalletError = error{
     ChainIdNotSet,
-    SigningFailed,
     ReceiptNotFound,
 };
 
@@ -155,8 +154,32 @@ pub const Wallet = struct {
         const signed_bytes = try self.signTransaction(eip1559_tx);
         defer self.allocator.free(signed_bytes);
 
-        // Broadcast
-        return try self.provider.sendRawTransaction(signed_bytes);
+        // Broadcast. A JSON-RPC error response does not prove the transaction
+        // missed the chain: the request can be delivered and the connection die
+        // before the response, after which a duplicate delivery is answered
+        // with an error (e.g. "already known") while the first copy mines.
+        // The hash is determined by the signed bytes, so on RpcError poll
+        // briefly for a receipt and report success if the transaction landed.
+        const tx_hash = keccak.hash(signed_bytes);
+        _ = self.provider.sendRawTransaction(signed_bytes) catch |err| {
+            if (err == error.RpcError and self.transactionLanded(tx_hash)) {
+                return tx_hash;
+            }
+            return err;
+        };
+        return tx_hash;
+    }
+
+    /// Whether a transaction has a receipt, polling a few times to let an
+    /// in-flight copy mine. Used to double-check ambiguous broadcast failures.
+    fn transactionLanded(self: *Wallet, tx_hash: [32]u8) bool {
+        var attempt: u32 = 0;
+        while (attempt < 3) : (attempt += 1) {
+            if (attempt > 0) runtime.sleepMs(self.provider.io(), 1_000);
+            const receipt = self.provider.getTransactionReceipt(tx_hash) catch continue;
+            if (receipt != null) return true;
+        }
+        return false;
     }
 
     /// Sign and send a transaction, then wait for the receipt by polling.
@@ -189,8 +212,11 @@ pub const Wallet = struct {
         // Hash the transaction for signing
         const msg_hash = try transaction_mod.hashForSigning(self.allocator, wrapped);
 
-        // Sign the hash
-        const sig = self.signer.signHash(msg_hash) catch return error.SigningFailed;
+        // Sign the hash. Propagate the signer's own error: for a KMS signer
+        // this distinguishes a failed HTTPS call (RequestFailed) from bad
+        // credentials (Unauthorized) or a recovery mismatch (AddressMismatch),
+        // which a blanket SigningFailed used to hide.
+        const sig = try self.signer.signHash(msg_hash);
 
         // For EIP-1559 (type 2) transactions, v is the raw recovery id (0 or 1)
         return try transaction_mod.serializeSigned(self.allocator, wrapped, sig.r, sig.s, sig.v);
@@ -294,6 +320,43 @@ test "Wallet.signTransaction is deterministic" {
     defer std.testing.allocator.free(signed2);
 
     try std.testing.expectEqualSlices(u8, signed1, signed2);
+}
+
+// `sendTransaction` reports an ambiguous broadcast failure as landed by
+// polling for the receipt of a hash it computes locally, before broadcasting,
+// as keccak256 of the signed bytes. This locks that hash to the canonical
+// EIP-1559 transaction hash, cross-checked against viem (an independent
+// implementation) for the well-known Anvil key #0.
+test "signed-tx keccak matches the canonical transaction hash" {
+    const hex = @import("hex.zig");
+    const private_key = try hex.hexToBytesFixed(32, "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
+
+    var transport = http_transport_mod.HttpTransport.init(std.testing.allocator, "http://localhost:8545", runtime.blockingIo());
+    defer transport.deinit();
+    var provider = provider_mod.Provider.init(std.testing.allocator, &transport);
+    var wallet = Wallet.initLocal(std.testing.allocator, private_key, &provider);
+    wallet.chain_id = 1;
+
+    const tx = transaction_mod.Eip1559Transaction{
+        .chain_id = 1,
+        .nonce = 5,
+        .max_priority_fee_per_gas = 2_000_000_000,
+        .max_fee_per_gas = 50_000_000_000,
+        .gas_limit = 100_000,
+        .to = @as([20]u8, @splat(0xaa)),
+        .value = 0,
+        .data = &.{ 0xa9, 0x05, 0x9c, 0xbb },
+        .access_list = &.{},
+    };
+
+    const signed = try wallet.signTransaction(tx);
+    defer std.testing.allocator.free(signed);
+
+    const expected_signed = try hex.hexToBytesFixed(115, "02f87001058477359400850ba43b7400830186a094aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8084a9059cbbc001a096c40667fc8d708d1e2c548918533b952881d0f92aad790fa0e5d5d7fe2e0643a06e7d62e317516b359c31c63dbb0e9fb73d06ecf473f5f013211cdab71db3198c");
+    try std.testing.expectEqualSlices(u8, &expected_signed, signed);
+
+    const expected_hash = try hex.hexToBytesFixed(32, "7a8921f4543662f78b5ff4917258d8a32ce704a3df7dc9789b24000dce29afab");
+    try std.testing.expectEqualSlices(u8, &expected_hash, &keccak.hash(signed));
 }
 
 test "SendTransactionOpts defaults" {


### PR DESCRIPTION
## Motivation

Root-caused from a 21-minute production outage in the gator liquidator on 2026-07-09: every batch-liquidation send failed, strictly alternating `error.SigningFailed` / `error.RpcError`, then self-recovered. Tracing both error paths to source turned up three distinct defects in this repo's send path.

## Changes

**1. KMS: retry once on a stale keep-alive connection** (`src/kms.zig`)

Signing calls are often minutes apart, and KMS closes idle keep-alive connections well before that. The pooled connection is therefore routinely dead when the next `kms:Sign` reuses it, so the first write fails; the failed fetch discards that connection and one retry dials fresh. This was the `SigningFailed` half of the outage — it fired on every *other* attempt, which is exactly the strict alternation seen in the logs.

**2. Wallet: propagate the signer's real error** (`src/wallet.zig`)

`signHash catch return error.SigningFailed` collapsed every signer failure into one opaque error. For a KMS signer this hid whether the cause was a failed HTTPS call (`RequestFailed`), bad credentials (`Unauthorized`), or a recovery mismatch (`AddressMismatch`). Now propagated. Removes the now-unused `WalletError.SigningFailed`.

**3. Wallet: verify ambiguous broadcasts before reporting failure** (`src/wallet.zig`)

A JSON-RPC error on `eth_sendRawTransaction` does not prove the transaction missed the chain: a redelivered request can be answered `already known` while the first copy mines. This actually happened in the outage — a send logged as `RpcError` liquidated its position on-chain, and the caller wrongly treated it as failed (put the position in cooldown instead of marking it liquidated). The transaction hash is fully determined by the signed bytes, so on `RpcError` we now poll briefly for that hash's receipt and report success if it landed.

Adds a test that cross-checks the pre-broadcast hash against **viem** (independent implementation) for the well-known Anvil key #0, locking the `keccak256(signed_bytes)` == canonical-tx-hash invariant the receipt poll depends on.

## Testing

- `zig build test` — 856/856 pass (was 855; +1 new cross-validation test)
- `zig fmt --check src/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction sending is more resilient when a broadcast error occurs, with automatic confirmation checking before reporting failure.

* **Bug Fixes**
  * Improved handling of flaky network connections when calling KMS services by retrying failed requests.
  * Transaction hashes are now derived consistently from signed transaction bytes before broadcast.
  * Signing errors are now reported more accurately, and transaction-not-found cases are handled explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->