### PR TITLE
perf: route safeDiv through divLimbsDirect (not the builtin u256 /)

### DIFF
--- a/src/uint256.zig
+++ b/src/uint256.zig
@@ -82,9 +82,14 @@ pub fn safeMul(a: u256, b: u256) ?u256 {
 }
 
 /// Division (returns null on divide by zero).
+///
+/// Routes through the limb-based `divLimbsDirect` rather than the builtin
+/// `u256 /`, which lowers to a slow software long-division on aarch64
+/// (measured ~330ns for a 256/128-bit divide vs a few tens of ns here). Same
+/// fast path `mulDiv` and the dex math already use.
 pub fn safeDiv(a: u256, b: u256) ?u256 {
     if (b == 0) return null;
-    return a / b;
+    return limbsToU256(divLimbsDirect(u256ToLimbs(a), u256ToLimbs(b)));
 }
 
 /// Fast u256 division using u64-limb schoolbook algorithm.


### PR DESCRIPTION
## What

`uint256.safeDiv` was `return a / b;` &mdash; the builtin `u256` division, which lowers to a slow software long-division on aarch64 (measured **~330 ns** for a 256/128-bit divide). This routes it through the limb-based `divLimbsDirect` the library already ships and that `mulDiv` / the dex math already use (Knuth Algorithm D over `[4]u64` with `div128by64` = 2 hardware UDIVs).

## Why it matters

`safeDiv` is the public division helper, so every caller silently paid the slow path while the fast implementation sat one call away. Found while chasing a Uniswap TickMath hotspot in a downstream SDK: the positive-tick `maxInt/ratio` divide dominated the function, and swapping the builtin `/` for `divLimbsDirect` was a ~3&times; win on that op alone (and ~6.5&times; on the whole function combined with limb multiply).

## Safety

No behavior change &mdash; `divLimbsDirect` returns the same quotient as `/` (it's already the tested primitive behind `mulDiv`). The full suite passes: **856/856**, including the `safeDiv` and `divLimbsDirect` cases. `zig fmt --check` clean.

## Follow-up (not in this PR)

The internal `divLimbs` (used nowhere on the public path now) still calls `knuthDivCore` directly, skipping `divLimbsDirect`'s 2-limb register fast path. Worth aligning if it gains callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved large-integer division reliability and performance.
  * Division by zero continues to be handled safely without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->